### PR TITLE
Add karma high-score and high-giver reports to GraphQL API

### DIFF
--- a/resources/graphql-schema.edn
+++ b/resources/graphql-schema.edn
@@ -79,6 +79,11 @@
                     :score {:type Int}}}
            }
 
+ :enums {:karma_report {:values [{:enum-value :SCORES
+                                  :description "Users with the most amassed karma"}
+                                 {:enum-value :GIVERS
+                                  :description "User who have bestored the most karma"}]}}
+
  :queries {:eval {:type (list String)
                   :args {:expr {:type String}}
                   :resolve :eval}
@@ -137,5 +142,8 @@
                        :resolve :crons}
 
            :karmas {:type (list :karma)
-                    :resolve :karmas}
+                    :resolve :karmas
+                    :args {:report {:type :karma_report}
+                           :limit {:type Int
+                                   :default-value 10}}}
            }}

--- a/src/yetibot/core/models/karma.clj
+++ b/src/yetibot/core/models/karma.clj
@@ -18,21 +18,35 @@
     (if (nil? score) 0 score)))
 
 (defn get-notes
-  [user-id]
-  (map #(update % :created-at time.coerce/from-date)
-       (db/query {:select/clause "note, voter_id, created_at"
-                  :where/map {:user-id user-id}
-                  :where/clause "note IS NOT NULL AND points > 0"
-                  :order/clause "created_at DESC"
-                  :limit/clause 3})))
+  ([user-id] (get-notes user-id 3))
+  ([user-id cnt]
+   (let [cnt (if (or (<= cnt 0) (> cnt 100)) 3 cnt)]
+     (map #(update % :created-at time.coerce/from-date)
+          (db/query {:select/clause "note, voter_id, created_at"
+                     :where/map {:user-id user-id}
+                     :where/clause "note IS NOT NULL AND points > 0"
+                     :order/clause "created_at DESC"
+                     :limit/clause cnt})))))
 
 (defn get-high-scores
-  []
-  (db/query {:select/clause "user_id, SUM(points) as score"
-             :group/clause "user_id"
-             :having/clause "SUM(points) > 0"
-             :order/clause "score DESC"
-             :limit/clause 10}))
+  ([] (get-high-scores 10))
+  ([cnt]
+   (let [cnt (if (or (<= cnt 0) (> cnt 100)) 10 cnt)]
+     (db/query {:select/clause "user_id, SUM(points) as score"
+                :group/clause "user_id"
+                :having/clause "SUM(points) > 0"
+                :order/clause "score DESC"
+                :limit/clause cnt}))))
+
+(defn get-high-givers
+  ([] (get-high-givers 10))
+  ([cnt]
+   (let [cnt (if (or (<= cnt 0) (> cnt 100)) 10 cnt)]
+     (db/query {:select/clause "voter_id, SUM(points) as score"
+                :group/clause "voter_id"
+                :having/clause "SUM(points) > 0"
+                :order/clause "score DESC"
+                :limit/clause cnt}))))
 
 (defn delete-user!
   [user-id]

--- a/src/yetibot/core/webapp/resolvers.clj
+++ b/src/yetibot/core/webapp/resolvers.clj
@@ -109,8 +109,13 @@
   (db.cron/query {:query/identifiers identity}))
 
 (defn karmas-resolver
-  [context {:keys [] :as args} value]
-  (map (fn [{:keys [user-id score]}]
-         {:user_id user-id
-          :score score})
-       (karma/get-high-scores)))
+  [context {:keys [report limit] :as args} value]
+  (condp = report
+    :SCORES (map (fn [{:keys [user-id score]}]
+                   {:user_id user-id
+                    :score score})
+                 (karma/get-high-scores limit))
+    :GIVERS (map (fn [{:keys [voter-id score]}]
+                   {:user_id voter-id
+                    :score score})
+                 (karma/get-high-givers limit))))

--- a/test/yetibot/core/test/models/karma.clj
+++ b/test/yetibot/core/test/models/karma.clj
@@ -7,44 +7,62 @@
    [clj-time.coerce :as time.coerce]))
 
 (def epoch (time.coerce/to-long (time/now)))
-(def test-user (str "test-user-" epoch))
-(def test-voter (str "test-voter-" epoch))
+(def test-user-0 (str "test-user-0-" epoch))
+(def test-voter-0 (str "test-voter-0-" epoch))
 (def test-note (str "test-note-" epoch))
+
+(def test-user-1 (str "test-user-1-" epoch))
+(def test-voter-1 (str "test-voter-1-" epoch))
+
+(def max-scores 100)
 
 (namespace-state-changes (before :contents (db/start)))
 
-(with-state-changes [(after :facts (delete-user! test-user))]
+(with-state-changes [(after :facts (do (delete-user! test-user-0)
+                                       (delete-user! test-user-1)))]
 
   (fact "a non-existing user has a score of 0"
-        (get-score test-user) => 0)
+        (get-score test-user-0) => 0)
 
   (fact "a user's score can be incremented"
-        (add-score-delta! test-user test-voter 1 nil)
-        (get-score test-user) => 1)
+        (add-score-delta! test-user-0 test-voter-0 1 nil)
+        (get-score test-user-0) => 1)
 
   (fact "a user's score can be decremented"
-        (add-score-delta! test-user test-voter -1 nil)
-        (get-score test-user) => -1)
+        (add-score-delta! test-user-0 test-voter-0 -1 nil)
+        (get-score test-user-0) => -1)
 
   (fact "score updates save an optional note"
-        (add-score-delta! test-user test-voter 1 test-note)
-        (-> (get-notes test-user) first :note) => test-note)
+        (add-score-delta! test-user-0 test-voter-0 1 test-note)
+        (-> (get-notes test-user-0) first :note) => test-note)
 
   (fact "score changes save voter attribution"
-        (add-score-delta! test-user test-voter 1 test-note)
-        (-> (get-notes test-user) first :voter-id) => test-voter)
+        (add-score-delta! test-user-0 test-voter-0 1 test-note)
+        (-> (get-notes test-user-0) first :voter-id) => test-voter-0)
 
   (fact "created-at timestamp seems reasonable"
-        (add-score-delta! test-user test-voter 1 test-note)
-        (let [created-at (-> (get-notes test-user) first :created-at time.coerce/to-long)
+        (add-score-delta! test-user-0 test-voter-0 1 test-note)
+        (let [created-at (-> (get-notes test-user-0) first :created-at time.coerce/to-long)
               now        (-> (time/now) time.coerce/to-long)]
           (-> (- now created-at) (< 60)) => truthy))
 
   (fact "get-high-scores returns at least one item"
-        (add-score-delta! test-user test-voter 1 nil)
-        (-> (get-high-scores) count (>= 1)) => truthy)
+        (add-score-delta! test-user-0 test-voter-0 1 nil)
+        (-> (get-high-scores max-scores) count (>= 1)) => truthy)
 
+  ;; Brittle, potential for false negative, as we (intentionally)
+  ;; don't clear the DB.
   (fact "get-high-scores should not includes scores of 0 or less"
-        (add-score-delta! test-user test-voter 1 nil)
-        (add-score-delta! test-user test-voter -1 nil)
-        (->> (get-high-scores) (filter #(= (:user-id %) test-user)) count) => 0))
+        (add-score-delta! test-user-0 test-voter-0 1 nil)
+        (add-score-delta! test-user-0 test-voter-0 -1 nil)
+        (->> (get-high-scores max-scores) (filter #(= (:user-id %) test-user-0)) count) => 0)
+
+  (fact "get-high-scores respects limit"
+        (add-score-delta! test-user-0 test-voter-0 1 nil)
+        (add-score-delta! test-user-1 test-voter-0 1 nil)
+        (-> (get-high-scores 1) count (= 1)) => truthy)
+
+  (fact "get-high-givers respects limit"
+        (add-score-delta! test-user-0 test-voter-0 1 nil)
+        (add-score-delta! test-user-0 test-voter-1 1 nil)
+        (-> (get-high-givers 1) count (= 1)) => truthy))


### PR DESCRIPTION
Now accepting limits on count of returned karma records for aggregate reports, in stead of hard coding to 10.  Our model defends the DB, forcing a range of 1 - 100.

Some new tests added to kick the tires of both reports.