### PR TITLE
Allow non-map results in xargs

### DIFF
--- a/src/yetibot/core/commands/collections.clj
+++ b/src/yetibot/core/commands/collections.clj
@@ -142,7 +142,7 @@
         ((resolve cmd-runner)
          (fn [item]
            (try
-             (let [{:result/keys [value error] :as cmd-result}
+             (let [cmd-result
                    (apply handle-cmd
                           ;; item could be a collection, such as when xargs is
                           ;; used on nested collections, e.g.:
@@ -151,6 +151,11 @@
                             [args (merge cmd-params {:raw item :opts item})]
                             [(psuedo-format args item)
                              (merge cmd-params {:raw item :opts nil})]))
+
+                   [value error] (if (map? cmd-result)
+                                   ((juxt :result/value :result/error)
+                                    cmd-result)
+                                   [cmd-result nil])
                    _ (info "xargs cmd-result" (pr-str cmd-result))]
                (or error value cmd-result))
              (catch Exception ex


### PR DESCRIPTION
Allows commands like:

```
!range 1 5 | xargs repeat %s echo :yetibot: | xargs join
```

e.g. 
![image](https://user-images.githubusercontent.com/86107/55192699-bbc2cd80-516a-11e9-9182-98d14070be24.png)
