### PR TITLE
Convert `previous-value` to string before attempting to check `empty?` on it

### DIFF
--- a/src/yetibot/core/interpreter.clj
+++ b/src/yetibot/core/interpreter.clj
@@ -1,7 +1,6 @@
 (ns yetibot.core.interpreter
   "Handles evaluation of a parse tree"
   (:require
-    [clojure.string :refer [blank?]]
     [yetibot.core.chat :refer [suppress]]
     [yetibot.core.models.default-command :refer [fallback-enabled?
                                                  configured-default-command]]

--- a/src/yetibot/core/interpreter.clj
+++ b/src/yetibot/core/interpreter.clj
@@ -1,6 +1,7 @@
 (ns yetibot.core.interpreter
   "Handles evaluation of a parse tree"
   (:require
+    [clojure.string :refer [blank?]]
     [yetibot.core.chat :refer [suppress]]
     [yetibot.core.models.default-command :refer [fallback-enabled?
                                                  configured-default-command]]
@@ -35,8 +36,7 @@
   (debug "pipe-cmds" *chat-source* acc cmd-with-args next-cmds)
   (let [;; the previous accumulated value. for the first command in a series of
         ;; piped commands, preivous-value and previous-data will be empty
-        {previous-value :value
-         previous-data :data} acc
+        {previous-value :value previous-data :data} acc
         extra {:raw previous-value
                :data (or previous-data previous-value)
                :settings (:settings acc)
@@ -71,8 +71,8 @@
                 [cmd-with-args (conj extra {:opts possible-opts})]
                 ;; value is the previous primitive output from the last
                 ;; command. the first time around value is empty so just use
-                ;; the raw cmd-with-args
-                [(if (empty? previous-value)
+                ;; the raw cmd-with-args.
+                [(if (empty? (str previous-value))
                    cmd-with-args
                    ;; next time apply pseudo-format to support %s substitution
                    (pseudo-format cmd-with-args previous-value))

--- a/src/yetibot/core/util/format.clj
+++ b/src/yetibot/core/util/format.clj
@@ -104,9 +104,9 @@
     s))
 
 (defn to-coll-if-contains-newlines
-  "Convert a String to a List if the string contains newlines. Bit of a hack but it
-   lets us get out of explicitly supporting streams in every command that we want
-   it."
+  "Convert a String to a List if the string contains newlines. Bit of a hack but
+   it lets us get out of explicitly supporting streams in every command that we
+   want it."
   [s]
   (if (and (string? s) (re-find #"\n" s))
     (s/split s #"\n")


### PR DESCRIPTION
This prevents an error if previous-value was not a string, such as when
a command incorrectly returns a number, or `data` is used to extract some
number from a data structure which is then passed across a pipe

The error was:

```
java.lang.IllegalArgumentException: Don't know how to create ISeq from: java.lang.Long
```