### PR TITLE
Karma self-karma addition regression fix

### DIFF
--- a/src/yetibot/core/commands/karma.clj
+++ b/src/yetibot/core/commands/karma.clj
@@ -9,18 +9,15 @@
    [clj-time.format :as t]
    [clojure.spec.alpha :as s]))
 
-(comment
-
-  The Karma feature is presently only available for use in Slack.
-
-  Unfortunately Slack delivers reaction events by shortcode (actually
-  slightly modified string version).  Without an exhaustive mapping
-  there's no reliable way for us to support configrable emoji reaction
-  processing in Slack.  Unfortunately, this breaks IRC, where reactions
-  are then rendered as the shortcode string instead of the emoji
-  character.  We hope to improve this in the future.
-
-  )
+;; The Karma feature is presently only available for use in Slack.
+;;
+;; Slack delivers reaction events by shortcode (actually a slightly
+;; modified string version).  Without an exhaustive mapping there's no
+;; reliable way for us to support configrable emoji reaction
+;; processing in Slack, which we have prioritized.  Unfortunately,
+;; this breaks IRC, where response emjoi are then rendered as the
+;; shortcode string instead of the character.  We hope to improve this
+;; in the future.
 
 (def config (:value (get-config sch/Any [:karma])))
 
@@ -32,7 +29,7 @@
 
 (defn- fmt-user-score
   [user-id score]
-  (format "<%s>: %s\n" user-id score))
+  (format "<@%s>: %s\n" user-id score))
 
 (defn- fmt-user-notes
   [notes]
@@ -90,6 +87,6 @@
              :result/value reply-emoji}))))))
 
 (cmd-hook "karma"
-          #"^(?x) \s* (@\w[-\w]*\w) \s*$" get-score
-          #"^(?x) \s* (@\w[-\w]*\w) \s{0,2} (--|\+\+) (?: \s+(.+) )? \s*$" adjust-score
+          #"^(?x) \s* @(\w[-\w]*\w) \s*$" get-score
+          #"^(?x) \s* @(\w[-\w]*\w) \s{0,2} (--|\+\+) (?: \s+(.+) )? \s*$" adjust-score
           _ get-high-scores)

--- a/src/yetibot/core/commands/karma/specs.clj
+++ b/src/yetibot/core/commands/karma/specs.clj
@@ -7,7 +7,7 @@
 
 (s/def ::ctx (s/keys :req-un [::user]))
 
-(s/def ::user-id (s/and string? #(re-matches #"@\w[-\w]*\w" %)))
+(s/def ::user-id (s/and string? #(re-matches #"\w[-\w]*\w" %)))
 (s/def ::action (s/and string? (s/or :positive #(= "++" %)
                                      :negative #(= "--" %))))
 (s/def ::note (s/nilable string?))

--- a/src/yetibot/core/observers/karma.clj
+++ b/src/yetibot/core/observers/karma.clj
@@ -24,15 +24,15 @@
 
 (def cmd-re (re-pattern
              (str "^(?x) \\s* (" karma/pos-emoji "|" karma/neg-emoji ") \\s*"
-                  "(@\\w[-\\w]*\\w) \\s*"
+                  "@(\\w[-\\w]*\\w) \\s*"
                   "(?:--|\\+\\+)?"
                   "(?: \\s+(.+) )? \\s*$")))
 
 (defn- parse-react-event
   [e]
   {:voter-name (-> e :user :name)
-   :voter-id   (format "@%s" (-> e :user :id))
-   :user-id    (format "@%s" (-> e :message-user :id))})
+   :voter-id   (-> e :user :id)
+   :user-id    (-> e :message-user :id)})
 
 (defn- parse-message-event
   [{body :body user :user}]
@@ -40,7 +40,7 @@
     (let [action (if (= action karma/pos-emoji) "++" "--")]
       [action
        {:voter-name (:name user)
-        :voter-id   (format "@%s" (:id user))
+        :voter-id   (:id user)
         :user-id    user-id
         :note       note}])))
 
@@ -56,7 +56,7 @@
   [result]
   (if (contains? result :result/error)
     (:result/error result)
-    (format "%s <%s>: %d"
+    (format "%s <@%s>: %d"
             (:result/value result)
             (-> result :result/data :user-id)
             (-> result :result/data :score))))

--- a/test/yetibot/core/test/commands/karma.clj
+++ b/test/yetibot/core/test/commands/karma.clj
@@ -8,8 +8,8 @@
    [clj-time.coerce :as time.coerce]))
 
 (def epoch (time.coerce/to-long (time/now)))
-(def test-user (str "@test-user-" epoch))
-(def test-voter (str "@test-voter-" epoch))
+(def test-user (str "test-user-" epoch))
+(def test-voter (str "test-voter-" epoch))
 (def test-note (str "test-note-" epoch))
 (def test-score 1000000)
 (def _ "entire-match not used by test")

--- a/test/yetibot/core/test/commands/karma/specs.clj
+++ b/test/yetibot/core/test/commands/karma/specs.clj
@@ -7,8 +7,8 @@
    [clojure.spec.alpha :as s]))
 
 (def epoch (time.coerce/to-long (time/now)))
-(def test-user (str "@test-user-" epoch))
-(def test-voter (str "@test-voter-" epoch))
+(def test-user (str "test-user-" epoch))
+(def test-voter (str "test-voter-" epoch))
 (def test-note (str "test-note-" epoch))
 
 ;; The context passed to our command handlers
@@ -20,13 +20,12 @@
         (s/valid? ::karma.spec/ctx invalid-ctx) =not=> truthy))
 
 (fact user-id
-      (s/valid? ::karma.spec/user-id "@lake")       => truthy
-      (s/valid? ::karma.spec/user-id "@7lake")      => truthy
-      (s/valid? ::karma.spec/user-id "@lake7")      => truthy
-      (s/valid? ::karma.spec/user-id "@la-ke")      => truthy
-      (s/valid? ::karma.spec/user-id "lake")    =not=> truthy
-      (s/valid? ::karma.spec/user-id "@--lake") =not=> truthy
-      (s/valid? ::karma.spec/user-id "@lake--") =not=> truthy)
+      (s/valid? ::karma.spec/user-id "lake")       => truthy
+      (s/valid? ::karma.spec/user-id "7lake")      => truthy
+      (s/valid? ::karma.spec/user-id "lake7")      => truthy
+      (s/valid? ::karma.spec/user-id "la-ke")      => truthy
+      (s/valid? ::karma.spec/user-id "--lake") =not=> truthy
+      (s/valid? ::karma.spec/user-id "lake--") =not=> truthy)
 
 (fact action
       (first (s/conform ::karma.spec/action "++")) => :positive

--- a/test/yetibot/core/test/observers/karma.clj
+++ b/test/yetibot/core/test/observers/karma.clj
@@ -37,7 +37,8 @@
 
 (namespace-state-changes (before :contents (db/start)))
 
-(with-state-changes [(after :facts (model/delete-user! test-user))]
+(with-state-changes [(after :facts (do (model/delete-user! test-user)
+                                       (model/delete-user! test-voter)))]
 
   ;; Reaction Observer
   (fact "reaction-hook can increment karma for another user"


### PR DESCRIPTION
We now always strip the `@` char when parsing messages.  All internal
representation uses the base user-id.

Closes #91