### PR TITLE
Enable continuous delivery with git-derived version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,13 @@ before_script:
 env:
   - YETIBOT_DB_URL="postgresql://postgres@localhost:5432/yetibot"
 
-# TODO re-enable
-# script:
-#   - git checkout package-lock.json # ignore changes from npm
-#   - git status
-#   - lein test
-
 deploy:
   provider: script
   script:
   - git status
+  - git checkout package-lock.json # ignore changes from npm
+  - git status
+  - echo "Releasing..."
   - lein release
   # TODO switch this to master
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ deploy:
   # TODO switch this to master
   on:
     branch: derived-version
-    # ensure we only attempt to deploy once
-    condition: $TRAVIS_JOB_NUMBER =~ ^\d.1$
+    # ensure we only attempt to deploy once using jdk 11
+    jdk: oraclejdk11
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ before_script:
 env:
   - YETIBOT_DB_URL="postgresql://postgres@localhost:5432/yetibot"
 
-script: lein test
+script:
+  - git status
+  - git diff
+  - lein test
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ before_script:
 env:
   - YETIBOT_DB_URL="postgresql://postgres@localhost:5432/yetibot"
 
+before_deploy:
+  - git status
+    # clean up annoying package-lock.json changes
+  - git reset --hard
+
 deploy:
   provider: script
-  script:
-  - git status
-  - git checkout package-lock.json # ignore changes from npm
-  - git status
-  - echo "Releasing..."
-  - lein release
+  script: lein release
   # TODO switch this to master
   on:
     branch: derived-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,12 @@ env:
 
 script: lein test
 
+deploy:
+  provider: script
+  script: lein release
+  # TODO enable
+  # on:
+  #   branch: master
+
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,20 @@ before_script:
 env:
   - YETIBOT_DB_URL="postgresql://postgres@localhost:5432/yetibot"
 
-script:
-  - git checkout package-lock.json # ignore changes from npm
-  - git status
-  - lein test
+# TODO re-enable
+# script:
+#   - git checkout package-lock.json # ignore changes from npm
+#   - git status
+#   - lein test
 
 deploy:
   provider: script
   script:
   - git status
   - lein release
-  # TODO enable
-  # on:
-  #   branch: master
+  # TODO switch this to master
+  on:
+    branch: derived-version
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_deploy:
   - git reset --hard
 
 deploy:
+  # ensure we only attempt to deploy once
+  jdk: oraclejdk11
   provider: script
   script: lein release
   # TODO switch this to master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ before_deploy:
 deploy:
   provider: script
   script: lein release
-  # TODO switch this to master
   on:
-    branch: derived-version
+    branch: master
     # ensure we only attempt to deploy once using jdk 11
     jdk: oraclejdk11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: clojure
 lein: lein
+cache:
+  directories:
+    - $HOME/.m2
 jdk:
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ script: lein test
 
 deploy:
   provider: script
-  script: lein release
+  script: 
+  - git status
+  - git diff
+  - lein release
   # TODO enable
   # on:
   #   branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,14 @@ env:
   - YETIBOT_DB_URL="postgresql://postgres@localhost:5432/yetibot"
 
 script:
+  - git checkout package-lock.json # ignore changes from npm
   - git status
-  - git diff
   - lein test
 
 deploy:
   provider: script
-  script: 
+  script:
   - git status
-  - git diff
   - lein release
   # TODO enable
   # on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ before_deploy:
   - git reset --hard
 
 deploy:
-  # ensure we only attempt to deploy once
-  jdk: oraclejdk11
   provider: script
   script: lein release
   # TODO switch this to master
   on:
     branch: derived-version
+    # ensure we only attempt to deploy once
+    condition: $TRAVIS_JOB_NUMBER =~ ^\d.1$
 
 services:
   - postgresql

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yetibot.core :project/ref-short
+(defproject yetibot.core "_"
   :description "Core yetibot utilities, extracted for shared use among yetibot
                 and its various plugins"
   :url "https://github.com/yetibot/yetibot.core"
@@ -27,16 +27,20 @@
                    (println))}
   :git-version
   {:status-to-version
-   (fn [{:keys [tag version branch ahead ahead? dirty?] :as git}]
+   (fn [{:keys [timestamp ref-short tag version branch ahead ahead? dirty?] :as git}]
      (println "status-to-version: " (pr-str git))
-     (assert (re-find #"\d+\.\d+\.\d+" tag)
-             "Tag is assumed to be a raw SemVer version")
-     (if (and tag (not ahead?) (not dirty?))
-       tag
-       (let [[_ prefix patch] (re-find #"(\d+\.\d+)\.(\d+)" tag)
-             patch            (Long/parseLong patch)
-             patch+           (inc patch)]
-         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))))}
+     (assert (re-find #"\d+.*" tag) "Tag should start with numbers")
+     (when tag
+       (let [[_ x] (re-find #"(\d+).*" tag)
+             y ahead
+             z (.format
+                (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss'Z'")
+                  (.setTimeZone (java.util.TimeZone/getTimeZone "UTC")))
+                (if timestamp
+                  (java.util.Date. (* 1000 timestamp))
+                  (java.util.Date.)))]
+         (println (format "%s.%s.%s-%s" x y z ref-short))
+         (format "%s.%s.%s-%s" x y z ref-short))))}
 
   ; :aot [yetibot.core.init]
   :resource-paths ["resources"

--- a/project.clj
+++ b/project.clj
@@ -179,14 +179,9 @@
 
   :aliases {"test" ["with-profile" "+test" "midje"]}
 
+  ;; release is purely derived from git sha and timestamp, so there's no need to
+  ;; commit, bump, or tag anything
   :release-tasks [["vcs" "assert-committed"]
-                  ["deps"]
-                  ["change" "version" "leiningen.release/bump-version" "release"]
-                  ["vcs" "commit"]
-                  ["vcs" "tag"]
-                  ["deploy"]
-                  ["change" "version" "leiningen.release/bump-version"]
-                  ["vcs" "commit"]
-                  ["vcs" "push"]]
+                  ["deploy"]]
 
   :npm {:dependencies [[yetibot-dashboard "0.7.2"]]})

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,6 @@
   :git-version
   {:status-to-version
    (fn [{:keys [timestamp ref-short tag version branch ahead ahead? dirty?] :as git}]
-     (println "status-to-version: " (pr-str git))
      ;; (assert (not dirty?) "Git workspace is dirty")
      (let [instant (.atZone
                     (if (and timestamp (number? (read-string timestamp)))
@@ -44,7 +43,6 @@
                      (java.time.format.DateTimeFormatter/ofPattern
                       "yyyyMMdd.HHmmss")
                      instant)]
-       (println (format "%s.%s" datetime ref-short))
        (format "%s.%s" datetime ref-short)))}
 
   ; :aot [yetibot.core.init]

--- a/project.clj
+++ b/project.clj
@@ -37,18 +37,12 @@
                       (java.time.Instant/now))
                     java.time.ZoneOffset/UTC)
 
-           date-part (.format
-                      (java.time.format.DateTimeFormatter/ofPattern "uuuu.MM.dd")
-                      instant)
-
-           hh (.getHour instant)
-           mm (.getMinute instant)
-           ss (.getSecond instant)
-
-           seconds-since-midnight (+ ss (* 60 (+ mm (* 60 hh)))) ]
-       (println {:hh hh :mm mm :ss ss})
-       (println (format "%s-%s-%s" date-part seconds-since-midnight ref-short))
-       (format "%s-%s-%s" date-part seconds-since-midnight ref-short)))}
+           datetime (.format
+                      (java.time.format.DateTimeFormatter/ofPattern
+                       "uuuuMMdd.HHmmss")
+                      instant)]
+       (println (format "%s.%s" datetime ref-short))
+       (format "%s.%s" datetime ref-short)))}
 
   ; :aot [yetibot.core.init]
   :resource-paths ["resources"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,10 @@
   :scm {:name "git" :url "https://github.com/yetibot/yetibot.core"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :deploy-repositories [["releases" :clojars]]
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_username
+                                     :password :env/clojars_password
+                                     :sign-releases false}]]
   :repl-options {:init-ns yetibot.core.repl
                  :timeout 120000
                  :prompt (fn [ns] (str "\u001B[35m[\u001B[34m" ns
@@ -38,9 +41,9 @@
                     java.time.ZoneOffset/UTC)
 
            datetime (.format
-                      (java.time.format.DateTimeFormatter/ofPattern
-                       "uuuuMMdd.HHmmss")
-                      instant)]
+                     (java.time.format.DateTimeFormatter/ofPattern
+                      "uuuuMMdd.HHmmss")
+                     instant)]
        (println (format "%s.%s" datetime ref-short))
        (format "%s.%s" datetime ref-short)))}
 

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,8 @@
                    ;; dashboard
                    "node_modules/yetibot-dashboard/build"]
   :main yetibot.core.init
-  :plugins [[lein-environ "1.1.0"]
+  :plugins [[com.roomkey/lein-v "7.1.0"]
+            [lein-environ "1.1.0"]
             [lein-npm "0.6.2"]]
   :profiles {:profiles/dev {}
              :dev [:profiles/dev

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yetibot.core "0.5.22-SNAPSHOT"
+(defproject yetibot.core :lein-v
   :description "Core yetibot utilities, extracted for shared use among yetibot
                 and its various plugins"
   :url "https://github.com/yetibot/yetibot.core"

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
   {:status-to-version
    (fn [{:keys [timestamp ref-short tag version branch ahead ahead? dirty?] :as git}]
      (println "status-to-version: " (pr-str git))
-     (assert (not dirty?) "Git workspace is dirty")
+     ;; (assert (not dirty?) "Git workspace is dirty")
      (let [instant (.atZone
                     (if (and timestamp (number? (read-string timestamp)))
                       (java.time.Instant/ofEpochMilli (* 1000 (read-string timestamp)))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yetibot.core "_"
+(defproject yetibot/core "_"
   :description "Core yetibot utilities, extracted for shared use among yetibot
                 and its various plugins"
   :url "https://github.com/yetibot/yetibot.core"

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Core yetibot utilities, extracted for shared use among yetibot
                 and its various plugins"
   :url "https://github.com/yetibot/yetibot.core"
-  :scm {:name "git" :url "https://github.com/yetibot/yetibot.core.git"}
+  :scm {:name "git" :url "https://github.com/yetibot/yetibot.core"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :deploy-repositories [["releases" :clojars]]

--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
 
            datetime (.format
                      (java.time.format.DateTimeFormatter/ofPattern
-                      "uuuuMMdd.HHmmss")
+                      "yyyyMMdd.HHmmss")
                      instant)]
        (println (format "%s.%s" datetime ref-short))
        (format "%s.%s" datetime ref-short)))}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yetibot.core :lein-v
+(defproject yetibot.core :project/ref-short
   :description "Core yetibot utilities, extracted for shared use among yetibot
                 and its various plugins"
   :url "https://github.com/yetibot/yetibot.core"
@@ -14,18 +14,30 @@
                  (do
                    (println)
                    (println
-                     (str
-                       "\u001B[37m"
-                       "  Welcome to the Yetibot dev REPL!"
-                       \newline
-                       "  Use \u001B[35m(\u001B[34mhelp\u001B[35m) "
-                       "\u001B[37mto see available commands."
-                       \newline
-                       \newline
-                       "\u001B[35m    λλλ"
-                       "\u001B[m"
-                       ))
+                    (str
+                     "\u001B[37m"
+                     "  Welcome to the Yetibot dev REPL!"
+                     \newline
+                     "  Use \u001B[35m(\u001B[34mhelp\u001B[35m) "
+                     "\u001B[37mto see available commands."
+                     \newline
+                     \newline
+                     "\u001B[35m    λλλ"
+                     "\u001B[m"))
                    (println))}
+  :git-version
+  {:status-to-version
+   (fn [{:keys [tag version branch ahead ahead? dirty?] :as git}]
+     (println "status-to-version: " (pr-str git))
+     (assert (re-find #"\d+\.\d+\.\d+" tag)
+             "Tag is assumed to be a raw SemVer version")
+     (if (and tag (not ahead?) (not dirty?))
+       tag
+       (let [[_ prefix patch] (re-find #"(\d+\.\d+)\.(\d+)" tag)
+             patch            (Long/parseLong patch)
+             patch+           (inc patch)]
+         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))))}
+
   ; :aot [yetibot.core.init]
   :resource-paths ["resources"
                    ;; yetibot-dashboard is an npm dep
@@ -33,7 +45,7 @@
                    ;; dashboard
                    "node_modules/yetibot-dashboard/build"]
   :main yetibot.core.init
-  :plugins [[com.roomkey/lein-v "7.1.0"]
+  :plugins [[me.arrdem/lein-git-version "2.0.8"]
             [lein-environ "1.1.0"]
             [lein-npm "0.6.2"]]
   :profiles {:profiles/dev {}


### PR DESCRIPTION
- enables auto releases from master - [example build](https://travis-ci.com/yetibot/yetibot.core/jobs/201998647)
- derives version from timestamp and git sha1 e.g. `20190521.222441.b9df505`

Blog post about these changes and CD in general is forthcoming. 