### PR TITLE
Throttle send-msg for IRC to prevent flooding.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -128,7 +128,7 @@
                  [clj-fuzzy "0.4.1"]
                  [robert/hooke "1.3.0"]
                  [clj-time "0.14.4"] ; includes joda-time
-                 [rate-gate "1.3.1"]
+                 [throttler "1.0.0"]
                  [expound "0.7.2"]
                  ; scheduling used for mail. could be replaced by
                  ; hara.io.scheduler


### PR DESCRIPTION
Allow 1 request per second with burstiness up to 5.
Use log/warn when server reports flooding.

Seems that 1 rps is the default setting for IRC protocol. I've played with different throttling strategies on freenode using `!range 20 | xargs echo` and seems that current one is pretty safe.