### PR TITLE
Handle "Nick in use" notice in IRC adapter.

### DIFF
--- a/test/yetibot/core/test/adapters/irc.clj
+++ b/test/yetibot/core/test/adapters/irc.clj
@@ -1,5 +1,6 @@
 (ns yetibot.core.test.adapters.irc
   (:require
+    [midje.sweet :refer [=> fact facts]]
     [yetibot.core.adapters :as adapters]
     [yetibot.core.adapters.irc :refer :all]
     [yetibot.core.chat :as chat]
@@ -30,3 +31,11 @@
       (:groups (list-groups)))
 
     ))
+
+(facts "next-nick should produce correct value"
+  (next-nick "yetibot") => "yetibot_"
+  (next-nick "yetibot_") => "yetibot__"
+  (next-nick "yetibot__") => "yetibot_0"
+  (next-nick "yetibot_0") => "yetibot_1"
+  (next-nick "yetibot_9") => "yetibot00"
+  (next-nick "999999999") => nil)


### PR DESCRIPTION
irclj uses separate thread for connection. Whenever "nick in use" occurs it calls callback and then throws Exception which stops the thread. (https://github.com/Raynes/irclj/blob/f230935cd94dc1c86ffb6677c1b6bb8675d3df94/src/irclj/process.clj#L91)

So in order to recover this siutation I have to stop/start adapter.
