### PR TITLE
Make yetibot log file path configurable

### DIFF
--- a/config/config.sample.edn
+++ b/config/config.sample.edn
@@ -69,7 +69,8 @@
              {:name "yetibot.core"
               :uri "http://yetibot.core/"}]},
   :endpoint "http://my-yetibot.com",
-  :log {:level "debug"},
+  :log {:level "debug"
+        :path "/var/log/yetibot/yetibot.log"},
   :s3 {:secret {:key ""},
        :access {:key ""}},
   :wordnik {:key ""},

--- a/src/yetibot/core/logging.clj
+++ b/src/yetibot/core/logging.clj
@@ -28,6 +28,8 @@
       (not= enabled "false")
       true)))
 
+(s/def ::log-file-path string?)
+
 (defn start []
   (timbre/set-config!
     {:level (log-level)
@@ -37,5 +39,5 @@
       ;; rolling log files
       :rolling-appender (rolling-appender
                           {:enabled? (rolling-appender-enabled?)
-                           :path "/var/log/yetibot/yetibot.log"
+                           :path (get-config ::log-file-path [:log :path])
                            :pattern :daily})}}))


### PR DESCRIPTION
This PR makes the _log file path_ configurable via the external `config.edn` file.

```
:log {:level "debug"
      :path "/var/log/yetibot/yetibot.log"}
```

can you PTAL @devth 

thanks ;-)