### PR TITLE
Migrate Gemini image and code commands from yetibot

### DIFF
--- a/src/yetibot/core/adapters/discord.clj
+++ b/src/yetibot/core/adapters/discord.clj
@@ -9,6 +9,7 @@
             [taoensso.timbre :as timbre]
             [yetibot.core.adapters.adapter :as adapter]
             [yetibot.core.handler :as handler]
+            [yetibot.core.webapp.routes.images :as images]
             [yetibot.core.chat :as chat])
   (:import [java.util Base64]))
 
@@ -109,13 +110,6 @@
 (defn- generated-image-id [msg]
   (second (re-matches #".*/generated-images/([^.]+)\.png$" (str/trim msg))))
 
-(defn- resolve-image-store []
-  (try
-    (require 'yetibot.webapp.routes.images)
-    (when-let [v (resolve 'yetibot.webapp.routes.images/image-store)]
-      (var-get v))
-    (catch Exception _ nil)))
-
 (def discord-max-message-length 2000)
 
 (defn- chunk-message [msg]
@@ -125,13 +119,12 @@
 (defn- send-msg [{:keys [conn]} msg]
   (try
     (if-let [id (generated-image-id msg)]
-      (when-let [store (resolve-image-store)]
-        (when-let [{:keys [data]} (get @store id)]
-          (let [bytes (.decode (Base64/getDecoder) ^String data)
-                stream (java.io.ByteArrayInputStream. bytes)]
-            @(messaging/create-message!
-              (:rest @conn) chat/*target*
-              :stream {:content stream :filename (str id ".png")}))))
+      (when-let [{:keys [data]} (get @images/image-store id)]
+        (let [bytes (.decode (Base64/getDecoder) ^String data)
+              stream (java.io.ByteArrayInputStream. bytes)]
+          @(messaging/create-message!
+            (:rest @conn) chat/*target*
+            :stream {:content stream :filename (str id ".png")})))
       (if (> (count msg) discord-max-message-length)
         (doseq [chunk (chunk-message msg)]
           @(messaging/create-message! (:rest @conn) chat/*target* :content chunk))

--- a/src/yetibot/core/commands/bameme.clj
+++ b/src/yetibot/core/commands/bameme.clj
@@ -1,0 +1,66 @@
+(ns yetibot.core.commands.bameme
+  (:require [clojure.string :as s]
+            [taoensso.timbre :refer [info error]]
+            [yetibot.core.hooks :refer [cmd-hook]]
+            [yetibot.core.util.image-input :as image-input]
+            [yetibot.core.util.gemini :as gemini]
+            [yetibot.core.webapp.routes.images :refer [store-image!]]))
+
+(def ^:private meme-system-prompt
+  "You are a meme image generator. Generate images that look like classic
+internet memes. The image MUST include:
+
+1. A funny, relevant background image or scene that matches the meme concept
+2. Bold white text with black outline (Impact font style) overlaid on the image
+3. Text should be placed at the TOP and/or BOTTOM of the image, like classic memes
+
+When the user provides a meme template name (like 'drake', 'distracted boyfriend',
+'expanding brain', 'one does not simply', 'change my mind', etc.), generate an
+image in that meme's visual style with the provided text.
+
+When the user provides text separated by '/' characters, treat each segment as a
+separate text region on the meme (top/bottom, or panel labels).
+
+Make the image funny, bold, and immediately recognizable as a meme.")
+
+(defn- build-meme-prompt
+  [input]
+  (if-let [[_ template text] (re-matches #"(?i)(.+?):\s*(.+)" input)]
+    (str "Create a meme in the style of the '" (s/trim template)
+         "' meme template with this text: " (s/trim text))
+    (str "Create a meme with this text: " input)))
+
+(defn bameme-cmd
+  "bameme <template>: <text> # generate a meme image using AI
+
+   Examples:
+   bameme drake: writing tests / shipping to prod
+   bameme distracted boyfriend: new js framework / my mass project / stability
+   bameme one does not simply: deploy on a friday
+   bameme this is fine: everything is on fire at work
+
+   Or without a template:
+   bameme when the code compiles on the first try"
+  {:yb/cat #{:img :meme}}
+  [{:keys [match chat-source]}]
+  (if (gemini/configured?)
+    (try
+      (let [{:keys [prompt image-urls]} (image-input/extract-images match chat-source)
+            meme-prompt (build-meme-prompt prompt)
+            _ (info "bameme: generating meme for:" prompt
+                    "with" (count image-urls) "input image(s)")
+            image (gemini/generate-image meme-prompt meme-system-prompt image-urls)
+            id (store-image! image)
+            base-url (gemini/yetibot-base-url)
+            image-url (format "%s/generated-images/%s.png" base-url id)]
+        (info "bameme: meme generated successfully, serving at" image-url)
+        {:result/value image-url
+         :result/data {:id id :prompt match :url image-url}})
+      (catch Exception e
+        (error "bameme: Gemini meme generation error:" (.getMessage e))
+        {:result/error (str "Meme generation failed: " (.getMessage e))}))
+    {:result/error
+     "Gemini API is not configured. Set `gemini.key` in config."}))
+
+(cmd-hook #"bameme"
+  #".+" bameme-cmd)

--- a/src/yetibot/core/commands/banana.clj
+++ b/src/yetibot/core/commands/banana.clj
@@ -1,0 +1,32 @@
+(ns yetibot.core.commands.banana
+  (:require [taoensso.timbre :refer [info error]]
+            [yetibot.core.hooks :refer [cmd-hook]]
+            [yetibot.core.util.image-input :as image-input]
+            [yetibot.core.util.gemini :as gemini]
+            [yetibot.core.webapp.routes.images :refer [store-image!]]))
+
+(defn banana-cmd
+  "banana <prompt> # generate an image using Gemini nano banana image generation"
+  {:yb/cat #{:img}}
+  [{:keys [match chat-source]}]
+  (if (gemini/configured?)
+    (try
+      (let [{:keys [prompt image-urls]} (image-input/extract-images match chat-source)
+            _ (info "banana: generating image for prompt:" prompt
+                    "with" (count image-urls) "input image(s)")
+            image (gemini/generate-image
+                   (str "Generate an image: " prompt) nil image-urls)
+            id (store-image! image)
+            base-url (gemini/yetibot-base-url)
+            image-url (format "%s/generated-images/%s.png" base-url id)]
+        (info "banana: image generated successfully, serving at" image-url)
+        {:result/value image-url
+         :result/data {:id id :prompt match :url image-url}})
+      (catch Exception e
+        (error "banana: Gemini image generation error:" (.getMessage e))
+        {:result/error (str "Image generation failed: " (.getMessage e))}))
+    {:result/error
+     "Gemini API is not configured. Set `gemini.key` in config."}))
+
+(cmd-hook #"banana"
+  #".+" banana-cmd)

--- a/src/yetibot/core/commands/code.clj
+++ b/src/yetibot/core/commands/code.clj
@@ -1,0 +1,312 @@
+(ns yetibot.core.commands.code
+  "Use Gemini to make a code change in a GitHub repo and open a pull request.
+
+   Example:
+
+     code yetibot/core increase banana budget
+
+   This clones the repo using Yetibot's existing GitHub token, checks out and
+   rebases on the latest trunk, runs the Gemini CLI to perform the requested
+   change, then commits, pushes a branch, and opens a PR back to the repo."
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.spec.alpha :as s]
+   [clojure.string :as string]
+   [clojure.data.json :as json]
+   [clj-http.client :as client]
+   [taoensso.timbre :refer [debug info warn error]]
+   [yetibot.core.config :refer [get-config]]
+   [yetibot.core.hooks :refer [cmd-hook]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
+
+;; ---------------------------------------------------------------------------
+;; Config
+;;
+;; Gemini config lives under [:gemini], sharing a single API key with the rest
+;; of Yetibot's Gemini features. At minimum a :key (Gemini API key) is required.
+;; Optionally override the CLI binary and the default org used when a repo is
+;; given without an owner.
+;;
+;;   YB_GEMINI_KEY          - Gemini API key (required)
+;;   YB_GEMINI_CLI          - path to the gemini CLI binary (default "gemini")
+;;   YB_GEMINI_DEFAULT_ORG  - org used when repo given without an owner
+;;
+;; The GitHub token is reused from the yetibot/github plugin's [:github :token]
+;; (YB_GITHUB_TOKEN).
+;; ---------------------------------------------------------------------------
+
+;; generic spec for fetching single string values out of arbitrary config paths
+(s/def ::str string?)
+
+(defn- config-str [path]
+  (:value (get-config ::str path)))
+
+;; The strongest Gemini coding model.
+(def model "gemini-2.5-pro")
+
+(defn gemini-key [] (config-str [:gemini :key]))
+(defn cli-bin [] (or (config-str [:gemini :cli]) "gemini"))
+(defn default-org [] (or (config-str [:gemini :default-org]) "yetibot"))
+
+(defn github-token
+  "Reuse Yetibot's existing GitHub token."
+  []
+  (config-str [:github :token]))
+
+(defn configured?
+  "The command is only available when both Gemini and a GitHub token are set."
+  []
+  (boolean (and (not (string/blank? (gemini-key)))
+                (not (string/blank? (github-token))))))
+
+;; ---------------------------------------------------------------------------
+;; Shell helpers
+;; ---------------------------------------------------------------------------
+
+(defn sh*
+  "Run a shell command, optionally in :dir with extra :env vars merged on top of
+   the current environment. Returns the clojure.java.shell result map."
+  [{:keys [dir env]} & args]
+  (let [full-env (when (seq env)
+                   (merge (into {} (System/getenv)) env))
+        opts (cond-> []
+               dir (conj :dir dir)
+               full-env (conj :env full-env))
+        result (apply shell/sh (concat args opts))]
+    (debug "sh" (pr-str (vec args)) "exit" (:exit result))
+    result))
+
+(defn redact
+  "Strip embedded credentials (e.g. the GitHub token in a clone URL) from a
+   string so they never end up in chat output or logs."
+  [s]
+  (when s
+    (-> s
+        ;; redact the password in scheme://user:password@ URLs (e.g. the
+        ;; GitHub token in https://x-access-token:TOKEN@github.com/...). This is
+        ;; idempotent: re-running over an already-redacted "user:***@" is a noop.
+        (string/replace #"(://[^:/@\s]+:)[^@\s]+(@)" "$1***$2")
+        ;; redact bare userinfo tokens with no password, e.g. https://TOKEN@host
+        (string/replace #"(://)[^:/@\s]+(@)" "$1***$2"))))
+
+(defn check-sh
+  "Like sh* but throws ex-info with captured (credential-redacted) output when
+   the command fails."
+  [ctx & args]
+  (let [{:keys [exit out err] :as result} (apply sh* ctx args)]
+    (when-not (zero? exit)
+      (throw (ex-info (redact (format "command failed (exit %s): %s\n%s"
+                                      exit (string/join " " args)
+                                      (or (not-empty (string/trim (str err)))
+                                          (string/trim (str out)))))
+                      {:exit exit
+                       :out (redact out)
+                       :err (redact err)
+                       :args (mapv redact args)})))
+    result))
+
+;; ---------------------------------------------------------------------------
+;; Pure-ish helpers
+;; ---------------------------------------------------------------------------
+
+(defn parse-repo
+  "Parse `owner/repo` or bare `repo` (using the default org) into [owner repo]."
+  [repo-arg]
+  (let [parts (-> repo-arg string/trim (string/split #"/"))]
+    (if (>= (count parts) 2)
+      [(first parts) (second parts)]
+      [(default-org) (first parts)])))
+
+(defn authed-clone-url
+  "HTTPS clone URL that embeds the token for push/pull auth."
+  [token owner repo]
+  (format "https://x-access-token:%s@github.com/%s/%s.git" token owner repo))
+
+(defn branch-name
+  "A unique branch name for the change."
+  []
+  (str "yetibot/code-" (System/currentTimeMillis)))
+
+(defn pr-title
+  "Derive a concise PR title from the instruction."
+  [instruction]
+  (let [trimmed (string/trim instruction)
+        one-line (-> trimmed (string/replace #"\s+" " "))
+        capped (if (> (count one-line) 72)
+                 (str (subs one-line 0 69) "...")
+                 one-line)]
+    (if (seq capped)
+      (str (string/upper-case (subs capped 0 1)) (subs capped 1))
+      "Yetibot change")))
+
+(defn pr-body
+  [instruction gemini-out]
+  (str "Requested via Yetibot:\n\n> " (string/trim instruction) "\n\n"
+       "This change was authored by the Gemini CLI (`" model "`) "
+       "and opened automatically by Yetibot 🤖.\n\n"
+       (when-not (string/blank? gemini-out)
+         (str "<details><summary>Gemini output</summary>\n\n```\n"
+              (string/trim gemini-out)
+              "\n```\n\n</details>\n"))))
+
+(defn- temp-dir []
+  (.toFile (Files/createTempDirectory "yetibot-code" (make-array FileAttribute 0))))
+
+(defn default-branch
+  "Detect the repo's default branch (trunk) from origin/HEAD."
+  [repo-dir]
+  (let [{:keys [exit out]} (sh* {:dir repo-dir}
+                                "git" "rev-parse" "--abbrev-ref" "origin/HEAD")]
+    (if (zero? exit)
+      (-> out string/trim (string/replace #"^origin/" ""))
+      "master")))
+
+(defn working-tree-dirty?
+  "Whether Gemini actually changed anything in the repo."
+  [repo-dir]
+  (-> (sh* {:dir repo-dir} "git" "status" "--porcelain")
+      :out
+      string/blank?
+      not))
+
+;; ---------------------------------------------------------------------------
+;; Gemini
+;; ---------------------------------------------------------------------------
+
+(defn build-gemini-prompt
+  "Wrap the user's instruction with guidance so the CLI edits files directly."
+  [instruction]
+  (str "You are an automated coding agent working in a cloned git repository. "
+       "Make the following change directly to the files in this repository, "
+       "keeping the change minimal and focused. Do not commit, push, or open a "
+       "pull request yourself — only edit files. When you are done, briefly "
+       "summarize what you changed.\n\n"
+       "Change to make:\n" (string/trim instruction)))
+
+(defn run-gemini
+  "Invoke the Gemini CLI in repo-dir to perform the coding instruction. Uses the
+   best configured coding model and auto-approves tool calls so it can edit
+   files non-interactively."
+  [repo-dir instruction]
+  (info "running gemini" (cli-bin) "model" model)
+  (check-sh {:dir repo-dir
+             :env {"GEMINI_API_KEY" (gemini-key)}}
+            (cli-bin)
+            "--model" model
+            "--yolo"
+            "--prompt" (build-gemini-prompt instruction)))
+
+;; ---------------------------------------------------------------------------
+;; GitHub
+;; ---------------------------------------------------------------------------
+
+(defn create-pull-request
+  "Open a PR via the GitHub REST API using the existing token."
+  [token owner repo {:keys [title body head base]}]
+  (let [{:keys [status body]}
+        (client/post (format "https://api.github.com/repos/%s/%s/pulls" owner repo)
+                     {:headers {"Authorization" (str "Bearer " token)
+                                "Accept" "application/vnd.github+json"
+                                "X-GitHub-Api-Version" "2022-11-28"}
+                      :content-type :json
+                      :as :json
+                      :coerce :always
+                      :throw-exceptions false
+                      :body (json/write-str {:title title
+                                             :body body
+                                             :head head
+                                             :base base})})]
+    (debug "create-pull-request status" status)
+    (if (<= 200 status 299)
+      body
+      (throw (ex-info (str "GitHub PR creation failed: "
+                           (or (:message body) status))
+                      {:status status :body body})))))
+
+;; ---------------------------------------------------------------------------
+;; Orchestration
+;; ---------------------------------------------------------------------------
+
+(defn file-pr
+  "End to end: clone, rebase on latest trunk, run Gemini, commit, push, open PR.
+   Returns the GitHub PR map (with :html_url) or throws."
+  [{:keys [owner repo instruction token]}]
+  (let [dir (temp-dir)
+        repo-dir dir
+        ctx {:dir repo-dir}
+        ;; embed the token only in env-free git operations via the remote URL
+        clone-url (authed-clone-url token owner repo)
+        branch (branch-name)]
+    (try
+      (info "cloning" (format "%s/%s" owner repo) "into" (str dir))
+      (check-sh {} "git" "clone" "--depth" "50" clone-url (str repo-dir))
+      ;; identify Yetibot as the committer
+      (check-sh ctx "git" "config" "user.name" "Yetibot")
+      (check-sh ctx "git" "config" "user.email" "yetibot@yetibot.com")
+      (let [trunk (default-branch repo-dir)]
+        (info "trunk is" trunk)
+        ;; make sure we're on the latest trunk before branching
+        (check-sh ctx "git" "checkout" trunk)
+        (check-sh ctx "git" "fetch" "origin" trunk)
+        (check-sh ctx "git" "pull" "--rebase" "origin" trunk)
+        (check-sh ctx "git" "checkout" "-b" branch)
+        ;; let Gemini do the work
+        (let [gemini-result (run-gemini repo-dir instruction)]
+          (when-not (working-tree-dirty? repo-dir)
+            (throw (ex-info "Gemini did not make any changes" {:type :no-changes})))
+          (check-sh ctx "git" "add" "-A")
+          (check-sh ctx "git" "commit" "-m" (pr-title instruction))
+          (check-sh ctx "git" "push" "-u" "origin" branch)
+          (create-pull-request token owner repo
+                               {:title (pr-title instruction)
+                                :body (pr-body instruction (:out gemini-result))
+                                :head branch
+                                :base trunk})))
+      (finally
+        ;; best-effort cleanup of the temp checkout
+        (try (sh* {} "rm" "-rf" (str dir))
+             (catch Exception e (warn "failed to clean up" (str dir) e)))))))
+
+(defn code-cmd
+  "code <owner/repo> <instruction> # use Gemini to make the change and open a PR"
+  {:yb/cat #{:util}}
+  [{[_ repo-arg instruction] :match}]
+  (let [token (github-token)]
+    (cond
+      (string/blank? (gemini-key))
+      "Gemini is not configured. Set the `:gemini :key` config (YB_GEMINI_KEY)."
+
+      (string/blank? token)
+      "No GitHub token configured. Set `:github :token` (YB_GITHUB_TOKEN)."
+
+      :else
+      (let [[owner repo] (parse-repo repo-arg)]
+        (try
+          (let [{:keys [html_url] :as pr}
+                (file-pr {:owner owner
+                          :repo repo
+                          :instruction instruction
+                          :token token})]
+            (if html_url
+              (format "Opened PR for %s/%s: %s" owner repo html_url)
+              (str "Opened PR but got no URL back: " (pr-str pr))))
+          (catch clojure.lang.ExceptionInfo e
+            (if (= :no-changes (:type (ex-data e)))
+              (do
+                (info "code: gemini made no changes for" (str owner "/" repo))
+                (format "Gemini didn't make any changes for %s/%s — try a more specific instruction."
+                        owner repo))
+              (do
+                (error "code command failed" e)
+                (str "Failed to open PR: " (.getMessage e)))))
+          (catch Exception e
+            (error "code command failed" e)
+            (str "Failed to open PR: " (.getMessage e))))))))
+
+;; Only register the command when both Gemini and GitHub are configured, in
+;; keeping with the convention used by other optionally-configured commands.
+(when (configured?)
+  (cmd-hook #"code"
+            #"^(\S+)\s+(.+)$" code-cmd))

--- a/src/yetibot/core/commands/code.clj
+++ b/src/yetibot/core/commands/code.clj
@@ -5,9 +5,13 @@
 
      code yetibot/core increase banana budget
 
-   This clones the repo using Yetibot's existing GitHub token, checks out and
+   This clones the repo using Yetibot's GitHub credentials, checks out and
    rebases on the latest trunk, runs the Gemini CLI to perform the requested
-   change, then commits, pushes a branch, and opens a PR back to the repo."
+   change, then commits, pushes a branch, and opens a PR back to the repo.
+
+   GitHub auth is either a static token (PAT) or a GitHub App, whichever is
+   configured — an App is preferred since it mints short-lived, repo-scoped
+   installation tokens instead of relying on a long-lived personal token."
   (:require
    [clojure.java.shell :as shell]
    [clojure.spec.alpha :as s]
@@ -19,7 +23,10 @@
    [yetibot.core.hooks :refer [cmd-hook]])
   (:import
    [java.nio.file Files]
-   [java.nio.file.attribute FileAttribute]))
+   [java.nio.file.attribute FileAttribute]
+   [java.security KeyFactory Signature]
+   [java.security.spec PKCS8EncodedKeySpec]
+   [java.util Base64]))
 
 ;; ---------------------------------------------------------------------------
 ;; Config
@@ -33,12 +40,21 @@
 ;;   YB_GEMINI_CLI          - path to the gemini CLI binary (default "gemini")
 ;;   YB_GEMINI_DEFAULT_ORG  - org used when repo given without an owner
 ;;
-;; The GitHub token is reused from the yetibot/github plugin's [:github :token]
-;; (YB_GITHUB_TOKEN).
+;; GitHub auth, in order of preference:
+;;
+;;   GitHub App (short-lived, repo-scoped installation tokens):
+;;     YB_GITHUB_APP_ID              - the App's ID
+;;     YB_GITHUB_APP_PRIVATE_KEY     - the App's PEM private key
+;;     YB_GITHUB_APP_INSTALLATION_ID - optional; auto-resolved per repo if unset
+;;
+;;   Static token (reused from the yetibot/github plugin's [:github :token]):
+;;     YB_GITHUB_TOKEN               - a personal access token
 ;; ---------------------------------------------------------------------------
 
 ;; generic spec for fetching single string values out of arbitrary config paths
 (s/def ::str string?)
+;; an App id may be configured as either a string or a number
+(s/def ::id (s/or :string string? :number number?))
 
 (defn- config-str [path]
   (:value (get-config ::str path)))
@@ -50,16 +66,32 @@
 (defn cli-bin [] (or (config-str [:gemini :cli]) "gemini"))
 (defn default-org [] (or (config-str [:gemini :default-org]) "yetibot"))
 
-(defn github-token
-  "Reuse Yetibot's existing GitHub token."
+(defn github-pat
+  "Yetibot's static GitHub token (PAT), if configured."
   []
   (config-str [:github :token]))
 
+(defn app-id []
+  (some-> (:value (get-config ::id [:github :app :id])) str))
+
+(defn app-private-key
+  "The GitHub App's PEM private key. Tolerates env-var encoded newlines (\\n)."
+  []
+  (some-> (config-str [:github :app :private-key])
+          (string/replace "\\n" "\n")))
+
+(defn app-configured? []
+  (boolean (and (not (string/blank? (app-id)))
+                (not (string/blank? (app-private-key))))))
+
+(defn github-auth-configured? []
+  (or (app-configured?) (not (string/blank? (github-pat)))))
+
 (defn configured?
-  "The command is only available when both Gemini and a GitHub token are set."
+  "The command is only available when Gemini and some GitHub auth are set."
   []
   (boolean (and (not (string/blank? (gemini-key)))
-                (not (string/blank? (github-token))))))
+                (github-auth-configured?))))
 
 ;; ---------------------------------------------------------------------------
 ;; Shell helpers
@@ -202,14 +234,122 @@
 ;; GitHub
 ;; ---------------------------------------------------------------------------
 
+(def ^:private api-base "https://api.github.com")
+
+(defn- gh-headers [auth]
+  {"Authorization" auth
+   "Accept" "application/vnd.github+json"
+   "X-GitHub-Api-Version" "2022-11-28"})
+
+(defn- gh-get [url auth]
+  (client/get url {:headers (gh-headers auth) :as :json
+                   :coerce :always :throw-exceptions false}))
+
+(defn- gh-ok
+  "Return the response body on 2xx, otherwise throw with the GitHub error."
+  [{:keys [status body]} what]
+  (if (<= 200 status 299)
+    body
+    (throw (ex-info (str what " failed: " (or (:message body) status))
+                    {:status status :body body}))))
+
+;; -- RS256 JWT (pure JDK; no BouncyCastle, to avoid classpath conflicts) ------
+
+(defn- b64url
+  "Base64url-encode bytes without padding, per the JWT spec."
+  [^bytes bs]
+  (.encodeToString (.withoutPadding (Base64/getUrlEncoder)) bs))
+
+(defn- pem->der
+  "Strip PEM armor and base64-decode the body to DER bytes."
+  [pem]
+  (-> pem
+      (string/replace #"-----(BEGIN|END)[A-Z ]+-----" "")
+      (string/replace #"\s" "")
+      (->> (.decode (Base64/getDecoder)))))
+
+(defn- der-tlv
+  "Build an ASN.1 tag-length-value with correctly encoded definite length."
+  [tag ^bytes content]
+  (let [n (count content)
+        len (cond
+              (< n 0x80) [n]
+              (< n 0x100) [0x81 n]
+              :else [0x82 (bit-shift-right n 8) (bit-and n 0xff)])]
+    (byte-array (concat [tag] (map unchecked-byte len) content))))
+
+(defn- pkcs1->pkcs8
+  "Wrap a PKCS#1 RSAPrivateKey (GitHub's default key format) in a PKCS#8
+   PrivateKeyInfo so the JDK KeyFactory can read it."
+  [^bytes pkcs1]
+  (let [version (byte-array [0x02 0x01 0x00])
+        rsa-alg (byte-array (map unchecked-byte
+                                 [0x30 0x0d 0x06 0x09 0x2a 0x86 0x48
+                                  0x86 0xf7 0x0d 0x01 0x01 0x01 0x05 0x00]))]
+    (der-tlv 0x30 (byte-array (concat version rsa-alg (der-tlv 0x04 pkcs1))))))
+
+(defn- rsa-private-key
+  "Load an RSA private key from a PEM string in either PKCS#8 or PKCS#1 form."
+  [pem]
+  (let [der (pem->der pem)
+        der (if (string/includes? pem "BEGIN RSA PRIVATE KEY")
+              (pkcs1->pkcs8 der)
+              der)]
+    (.generatePrivate (KeyFactory/getInstance "RSA")
+                      (PKCS8EncodedKeySpec. der))))
+
+(defn- rs256 [^String signing-input pem]
+  (b64url (-> (doto (Signature/getInstance "SHA256withRSA")
+                (.initSign (rsa-private-key pem))
+                (.update (.getBytes signing-input "UTF-8")))
+              (.sign))))
+
+(defn app-jwt
+  "A short-lived (≤10m) RS256 JWT identifying the GitHub App, per GitHub's spec.
+   `iat` is backdated 60s to tolerate clock skew."
+  []
+  (let [now (quot (System/currentTimeMillis) 1000)
+        seg (fn [m] (b64url (.getBytes (json/write-str m) "UTF-8")))
+        signing-input (str (seg {:alg "RS256" :typ "JWT"})
+                           "."
+                           (seg {:iat (- now 60) :exp (+ now (* 9 60)) :iss (app-id)}))]
+    (str signing-input "." (rs256 signing-input (app-private-key)))))
+
+(defn installation-id
+  "The App's installation id for owner/repo (config override or auto-resolved)."
+  [jwt-token owner repo]
+  (or (config-str [:github :app :installation-id])
+      (-> (gh-get (format "%s/repos/%s/%s/installation" api-base owner repo)
+                  (str "Bearer " jwt-token))
+          (gh-ok "GitHub App installation lookup")
+          :id)))
+
+(defn installation-token
+  "Mint a short-lived installation access token for owner/repo. Behaves like a
+   PAT for both git operations and the REST API."
+  [owner repo]
+  (let [jwt-token (app-jwt)
+        id (installation-id jwt-token owner repo)]
+    (-> (client/post (format "%s/app/installations/%s/access_tokens" api-base id)
+                     {:headers (gh-headers (str "Bearer " jwt-token))
+                      :as :json :coerce :always :throw-exceptions false})
+        (gh-ok "GitHub App token exchange")
+        :token)))
+
+(defn github-token
+  "Resolve a GitHub token for owner/repo: a freshly-minted App installation
+   token when an App is configured, otherwise the static PAT."
+  [owner repo]
+  (if (app-configured?)
+    (installation-token owner repo)
+    (github-pat)))
+
 (defn create-pull-request
-  "Open a PR via the GitHub REST API using the existing token."
+  "Open a PR via the GitHub REST API using the resolved token."
   [token owner repo {:keys [title body head base]}]
   (let [{:keys [status body]}
-        (client/post (format "https://api.github.com/repos/%s/%s/pulls" owner repo)
-                     {:headers {"Authorization" (str "Bearer " token)
-                                "Accept" "application/vnd.github+json"
-                                "X-GitHub-Api-Version" "2022-11-28"}
+        (client/post (format "%s/repos/%s/%s/pulls" api-base owner repo)
+                     {:headers (gh-headers (str "Bearer " token))
                       :content-type :json
                       :as :json
                       :coerce :always
@@ -273,37 +413,37 @@
   "code <owner/repo> <instruction> # use Gemini to make the change and open a PR"
   {:yb/cat #{:util}}
   [{[_ repo-arg instruction] :match}]
-  (let [token (github-token)]
-    (cond
-      (string/blank? (gemini-key))
-      "Gemini is not configured. Set the `:gemini :key` config (YB_GEMINI_KEY)."
+  (cond
+    (string/blank? (gemini-key))
+    "Gemini is not configured. Set the `:gemini :key` config (YB_GEMINI_KEY)."
 
-      (string/blank? token)
-      "No GitHub token configured. Set `:github :token` (YB_GITHUB_TOKEN)."
+    (not (github-auth-configured?))
+    "No GitHub auth configured. Set a GitHub App (`:github :app :id` + `:github :app :private-key`) or a token (`:github :token`)."
 
-      :else
-      (let [[owner repo] (parse-repo repo-arg)]
-        (try
-          (let [{:keys [html_url] :as pr}
-                (file-pr {:owner owner
-                          :repo repo
-                          :instruction instruction
-                          :token token})]
-            (if html_url
-              (format "Opened PR for %s/%s: %s" owner repo html_url)
-              (str "Opened PR but got no URL back: " (pr-str pr))))
-          (catch clojure.lang.ExceptionInfo e
-            (if (= :no-changes (:type (ex-data e)))
-              (do
-                (info "code: gemini made no changes for" (str owner "/" repo))
-                (format "Gemini didn't make any changes for %s/%s — try a more specific instruction."
-                        owner repo))
-              (do
-                (error "code command failed" e)
-                (str "Failed to open PR: " (.getMessage e)))))
-          (catch Exception e
-            (error "code command failed" e)
-            (str "Failed to open PR: " (.getMessage e))))))))
+    :else
+    (let [[owner repo] (parse-repo repo-arg)]
+      (try
+        (let [token (github-token owner repo)
+              {:keys [html_url] :as pr}
+              (file-pr {:owner owner
+                        :repo repo
+                        :instruction instruction
+                        :token token})]
+          (if html_url
+            (format "Opened PR for %s/%s: %s" owner repo html_url)
+            (str "Opened PR but got no URL back: " (pr-str pr))))
+        (catch clojure.lang.ExceptionInfo e
+          (if (= :no-changes (:type (ex-data e)))
+            (do
+              (info "code: gemini made no changes for" (str owner "/" repo))
+              (format "Gemini didn't make any changes for %s/%s — try a more specific instruction."
+                      owner repo))
+            (do
+              (error "code command failed" e)
+              (str "Failed to open PR: " (.getMessage e)))))
+        (catch Exception e
+          (error "code command failed" e)
+          (str "Failed to open PR: " (.getMessage e)))))))
 
 ;; Only register the command when both Gemini and GitHub are configured, in
 ;; keeping with the convention used by other optionally-configured commands.

--- a/src/yetibot/core/db/image_budget.clj
+++ b/src/yetibot/core/db/image_budget.clj
@@ -1,0 +1,14 @@
+(ns yetibot.core.db.image-budget
+  (:require [yetibot.core.db.util :as db.util]))
+
+(def schema
+  {:schema/table "image_budget"
+   :schema/specs (into [[:month :text "NOT NULL"]
+                        [:image-count :integer "NOT NULL" "DEFAULT 0"]]
+                       (db.util/default-fields))})
+
+(def create (partial db.util/create (:schema/table schema)))
+
+(def query (partial db.util/query (:schema/table schema)))
+
+(def update-where (partial db.util/update-where (:schema/table schema)))

--- a/src/yetibot/core/util/gemini.clj
+++ b/src/yetibot/core/util/gemini.clj
@@ -1,0 +1,267 @@
+(ns yetibot.core.util.gemini
+  "Shared utilities for interacting with the Google Gemini API."
+  (:require [clj-http.client :as client]
+            [clojure.data.json :as json]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [taoensso.timbre :refer [info warn error]]
+            [yetibot.core.config :refer [get-config]]
+            [yetibot.core.db.image-budget :as image-budget])
+  (:import [java.time YearMonth]
+           [java.time.format DateTimeFormatter]
+           [java.util Base64]))
+
+(s/def ::key string?)
+
+(s/def ::cost (s/keys :opt-un [::per]))
+(s/def ::per (s/or :string string? :number number?))
+(s/def ::monthly (s/keys :opt-un [::budget]))
+(s/def ::budget (s/or :string string? :number number?))
+
+(s/def ::config (s/keys :req-un [::key] :opt-un [::cost ::monthly]))
+
+;; All Gemini settings live under [:gemini] and share a single API key
+;; (YB_GEMINI_KEY) with the rest of Yetibot's Gemini features.
+(def config (or (:value (get-config ::config [:gemini])) {}))
+
+(def default-model "gemini-3.1-flash-image-preview")
+
+(defn gemini-model [] default-model)
+
+(defn configured? []
+  (some? (:key config)))
+
+(defn- parse-number
+   "Parse a string to a number, returning the number unchanged if it's already a number.
+    Logs a warning and returns the original value if the string cannot be parsed."
+   [v]
+   (if (string? v)
+     (try
+       (Double/parseDouble v)
+       (catch Exception e
+         (warn "gemini: failed to parse number from config value" v e)
+         v))
+     v))
+
+;; -- Monthly budget throttling --
+
+(def ^:private default-cost-per-image
+   "Default estimated cost per generated image in USD (gemini-3.1-flash-image-preview pricing, tied to default-model)."
+   0.039)
+
+(def ^:private default-monthly-budget
+  "Default monthly budget in USD for image generation."
+  5.00)
+
+(defn- cost-per-image []
+   (or (parse-number (-> config :cost :per))
+       (case (gemini-model)
+         "gemini-3.1-flash-image-preview" 0.039
+         ;; Add other models and their costs here as needed
+         default-cost-per-image)))
+
+(defn- monthly-budget []
+   (or (parse-number (-> config :monthly :budget)) default-monthly-budget))
+
+(defn- max-images-per-month []
+  (long (Math/floor (/ (monthly-budget) (cost-per-image)))))
+
+(defn- current-month []
+  (.format (YearMonth/now) (DateTimeFormatter/ofPattern "yyyy-MM")))
+
+(defonce ^:private usage-tracker (atom {:month (current-month) :count 0}))
+
+(defonce ^:private db-loaded? (atom false))
+
+(defn- load-from-db!
+  "Load the current month's image count from the database on first access.
+   Falls back to in-memory only if the database is unavailable."
+  []
+  (when-not @db-loaded?
+    (try
+      (let [month (current-month)
+            rows (image-budget/query {:where/map {:month month}})]
+        (when-let [row (first rows)]
+          (reset! usage-tracker {:month month :count (:image-count row)})
+          (info "gemini: loaded image budget from db -"
+                (:image-count row) "images for" month))
+        (reset! db-loaded? true))
+      (catch Exception e
+        (warn "gemini: could not load image budget from db, using in-memory only:"
+              (.getMessage e))))))
+
+(defn- persist-to-db!
+  "Save the current month's usage count to the database."
+  [month cnt]
+  (try
+    (let [existing (first (image-budget/query {:where/map {:month month}}))]
+      (if existing
+        (image-budget/update-where {:month month} {:image-count cnt})
+        (image-budget/create {:month month :image-count cnt})))
+    (catch Exception e
+      (warn "gemini: could not persist image budget to db:" (.getMessage e)))))
+
+(defn- reset-if-new-month!
+  "Reset the usage counter if we've rolled into a new month."
+  []
+  (load-from-db!)
+  (let [month (current-month)]
+    (swap! usage-tracker
+           (fn [tracker]
+             (if (= (:month tracker) month)
+               tracker
+               (do (info "gemini: resetting monthly image budget counter for" month)
+                   {:month month :count 0}))))))
+
+(defn budget-status
+  "Return the current monthly budget status for image generation."
+  []
+  (reset-if-new-month!)
+  (let [{:keys [count]} @usage-tracker
+        max-imgs (max-images-per-month)
+        spent (* count (cost-per-image))
+        remaining (- (monthly-budget) spent)]
+    {:images-generated count
+     :max-images max-imgs
+     :spent (double spent)
+     :budget (monthly-budget)
+     :remaining (double remaining)
+     :month (:month @usage-tracker)}))
+
+(defn- check-budget!
+  "Throw if the monthly image generation budget has been exhausted."
+  []
+  (reset-if-new-month!)
+  (let [{:keys [count]} @usage-tracker
+        max-imgs (max-images-per-month)]
+    (when (>= count max-imgs)
+      (let [spent (* count (cost-per-image))]
+        (throw (ex-info
+                (format "Monthly image budget exhausted: %d/%d images ($%.2f/$%.2f). Resets next month."
+                        count max-imgs spent (monthly-budget))
+                {:type :budget-exceeded
+                 :count count
+                 :max max-imgs}))))))
+
+(defn- record-image-generated!
+  "Record that an image was successfully generated. Persists to db."
+  []
+  (let [{:keys [count month]} (swap! usage-tracker update :count inc)
+        max-imgs (max-images-per-month)]
+    (persist-to-db! month count)
+    (info (format "gemini: image generated (%d/%d this month, $%.2f/$%.2f)"
+                  count max-imgs
+                  (* count (cost-per-image))
+                  (monthly-budget)))))
+
+(defn- extract-image
+  "Extract the first image part from the Gemini API response."
+  [response-body]
+  (let [parts (get-in response-body [:candidates 0 :content :parts])]
+    (some (fn [part]
+            (when-let [inline-data (:inlineData part)]
+              {:data (:data inline-data)
+               :mime-type (:mimeType inline-data)}))
+          parts)))
+
+(defn- extract-api-error
+  "Extract a human-readable error message from a Gemini API error response body."
+  [body]
+  (try
+    (let [parsed (if (string? body)
+                   (json/read-str body :key-fn keyword)
+                   body)
+          error-obj (:error parsed)
+          message (:message error-obj)
+          status (:status error-obj)
+          code (:code error-obj)]
+      (if message
+        (str (when code (str "(" code ") "))
+             (when status (str status ": "))
+             message)
+        (str parsed)))
+    (catch Exception _
+      (if (string? body) body (str body)))))
+
+(defn- extract-block-reason
+  "Extract block/filter reason from a Gemini API response that returned no image."
+  [response-body]
+  (let [block-reason (get-in response-body [:promptFeedback :blockReason])
+        finish-reason (get-in response-body [:candidates 0 :finishReason])
+        safety-ratings (or (get-in response-body [:promptFeedback :safetyRatings])
+                           (get-in response-body [:candidates 0 :safetyRatings]))
+        flagged (when safety-ratings
+                  (->> safety-ratings
+                       (filter #(#{"HIGH" "MEDIUM"} (:probability %)))
+                       (map :category)))]
+    (cond
+      block-reason
+      (str "Prompt blocked by Gemini: " block-reason
+           (when (seq flagged)
+             (str " (flagged categories: " (string/join ", " flagged) ")")))
+
+      (and finish-reason (not= finish-reason "STOP"))
+      (str "Generation stopped: " finish-reason
+           (when (seq flagged)
+             (str " (flagged categories: " (string/join ", " flagged) ")")))
+
+      :else nil)))
+
+(defn- url->inline-part
+  "Fetch an image URL and return a Gemini inlineData part."
+  [image-url]
+  (let [resp (client/get image-url {:as :byte-array :throw-exceptions false})
+        content-type (get-in resp [:headers "Content-Type"] "image/png")
+        mime (first (string/split content-type #";"))]
+    (when (<= 200 (:status resp) 299)
+      {:inlineData {:mimeType mime
+                    :data (.encodeToString (Base64/getEncoder)
+                                           ^bytes (:body resp))}})))
+
+(defn generate-image
+  "Call the Gemini API to generate an image from a text prompt.
+   Accepts optional system-instruction and image-urls for multimodal input.
+   Checks monthly budget before making the API call and records usage on success."
+  ([prompt] (generate-image prompt nil nil))
+  ([prompt system-instruction] (generate-image prompt system-instruction nil))
+  ([prompt system-instruction image-urls]
+   (check-budget!)
+   (let [api-key (:key config)
+         model (gemini-model)
+         url (format
+              "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s"
+              model api-key)
+         image-parts (when (seq image-urls)
+                       (keep url->inline-part image-urls))
+         parts (into [{:text prompt}] image-parts)
+         body (cond-> {:contents [{:parts parts}]
+                       :generationConfig {:responseModalities ["TEXT" "IMAGE"]
+                                          :imageConfig {:imageSize "512"}}}
+                system-instruction
+                (assoc :systemInstruction
+                       {:parts [{:text system-instruction}]}))
+         response (client/post url
+                               {:content-type :json
+                                :body (json/write-str body)
+                                :as :json
+                                :throw-exceptions false})
+         status (:status response)]
+     (when-not (<= 200 status 299)
+       (let [error-msg (extract-api-error (:body response))]
+         (error "gemini: API error" status "-" error-msg)
+         (throw (ex-info (str "Gemini API error: " error-msg)
+                         {:type :gemini-api-error
+                          :status status}))))
+     (if-let [image (extract-image (:body response))]
+       (do (record-image-generated!)
+           image)
+       (let [reason (extract-block-reason (:body response))]
+         (throw (ex-info (or reason
+                              "No image was generated. Try a different prompt.")
+                         {:type :no-image-generated
+                          :response-body (:body response)})))))))
+
+(defn yetibot-base-url []
+  (or (:value (get-config string? [:url]))
+      (:value (get-config string? [:endpoint]))
+      "http://localhost:3003"))

--- a/src/yetibot/core/webapp/handler.clj
+++ b/src/yetibot/core/webapp/handler.clj
@@ -6,6 +6,7 @@
     [yetibot.core.webapp.routes.api :refer [api-routes]]
     [yetibot.core.webapp.routes.graphql :refer [graphql-routes]]
     [yetibot.core.webapp.routes.healthz :refer [healthz-routes]]
+    [yetibot.core.webapp.routes.images :refer [image-routes]]
     [yetibot.core.webapp.middleware :as middleware]
     [yetibot.core.webapp.session :as session]
     [yetibot.core.webapp.route-loader :as rl]
@@ -36,24 +37,16 @@
   (timbre/info "yetibot is shutting down...")
   (timbre/info "shutdown complete!"))
 
-(defn- resolve-image-routes []
-  (try
-    (require 'yetibot.webapp.routes.images)
-    (when-let [v (resolve 'yetibot.webapp.routes.images/image-routes)]
-      (var-get v))
-    (catch Exception _ nil)))
-
 (defn app []
   (let [plugin-routes (vec (rl/load-plugin-routes))
-        image-routes (resolve-image-routes)
         last-routes (conj plugin-routes base-routes)]
     (-> (apply routes
-               (cond-> [home-routes
-                        api-routes
-                        graphql-routes
-                        healthz-routes]
-                 image-routes (conj image-routes)
-                 true (into last-routes)))
+               (into [home-routes
+                      api-routes
+                      graphql-routes
+                      healthz-routes
+                      image-routes]
+                     last-routes))
         middleware/wrap-base)))
 
 ;; base-routes

--- a/src/yetibot/core/webapp/routes/images.clj
+++ b/src/yetibot/core/webapp/routes/images.clj
@@ -1,0 +1,35 @@
+(ns yetibot.core.webapp.routes.images
+  "Serves generated images stored in the in-memory image store."
+  (:require [compojure.core :refer [GET defroutes]]
+            [ring.util.response :as response])
+  (:import [java.util Base64]))
+
+(defonce image-store (atom {}))
+
+(def ^:private max-stored-images 100)
+
+(defn store-image!
+  "Store a base64-encoded image and return its unique ID.
+   Evicts the oldest entry when the store exceeds max-stored-images."
+  [{:keys [data mime-type] :as image-data}]
+  (let [id (str (java.util.UUID/randomUUID))]
+    (swap! image-store
+           (fn [store]
+             (let [store (assoc store id (assoc image-data :timestamp (System/currentTimeMillis)))]
+               (if (> (count store) max-stored-images)
+                 (let [oldest-key (->> store
+                                       (sort-by (comp :timestamp val))
+                                       first
+                                       key)]
+                   (dissoc store oldest-key))
+                 store))))
+    id))
+
+(defroutes image-routes
+  (GET "/generated-images/:id.png" [id]
+    (if-let [{:keys [data mime-type]} (get @image-store id)]
+      (let [bytes (.decode (Base64/getDecoder) ^String data)]
+        (-> (response/response (java.io.ByteArrayInputStream. bytes))
+            (response/content-type (or mime-type "image/png"))
+            (response/header "Cache-Control" "public, max-age=3600")))
+      (response/not-found "Image not found"))))

--- a/test/yetibot/core/test/commands/code.clj
+++ b/test/yetibot/core/test/commands/code.clj
@@ -3,8 +3,12 @@
    [midje.sweet :refer [fact facts => anything throws =throws=>]]
    [midje.checkers :refer [contains]]
    [clojure.string :as string]
+   [clojure.data.json :as json]
    [clj-http.client :as client]
-   [yetibot.core.commands.code :as code]))
+   [yetibot.core.commands.code :as code])
+  (:import
+   [java.security KeyPairGenerator Signature]
+   [java.util Arrays Base64]))
 
 (facts "about parse-repo"
   (fact "splits owner/repo"
@@ -88,25 +92,117 @@
      (client/post anything anything)
      => {:status 422 :body {:message "Validation Failed"}})))
 
+(defn- rsa-keypair []
+  (.generateKeyPair (doto (KeyPairGenerator/getInstance "RSA") (.initialize 2048))))
+
+(defn- pem [label ^bytes der]
+  (str "-----BEGIN " label "-----\n"
+       (.encodeToString (Base64/getMimeEncoder) der)
+       "\n-----END " label "-----\n"))
+
+(defn- pkcs8-pem [kp]
+  (pem "PRIVATE KEY" (.getEncoded (.getPrivate kp))))
+
+(defn- pkcs1-pem
+  "Derive a PKCS#1 PEM from a generated key by extracting the PKCS#1 body (the
+   PrivateKeyInfo OCTET STRING) out of its PKCS#8 encoding. For a 2048-bit key
+   that body sits after a fixed 26-byte PKCS#8 prefix."
+  [kp]
+  (let [pkcs8 (.getEncoded (.getPrivate kp))]
+    (pem "RSA PRIVATE KEY" (Arrays/copyOfRange pkcs8 26 (count pkcs8)))))
+
+(defn- jwt-verifies?
+  "Split a JWT, verify its RS256 signature against pub, and return the payload."
+  [token pub]
+  (let [[h p s] (string/split token #"\.")
+        signing-input (str h "." p)
+        ok? (-> (doto (Signature/getInstance "SHA256withRSA")
+                  (.initVerify pub)
+                  (.update (.getBytes signing-input "UTF-8")))
+                (.verify (.decode (Base64/getUrlDecoder) ^String s)))]
+    {:valid? ok?
+     :payload (json/read-str (String. (.decode (Base64/getUrlDecoder) ^String p))
+                             :key-fn keyword)}))
+
+(facts "about app-jwt"
+  (fact "signs an RS256 token (PKCS#8 key) verifiable with the matching public key"
+    (let [kp (rsa-keypair)]
+      (jwt-verifies? (code/app-jwt) (.getPublic kp))
+      => (fn [{:keys [valid? payload]}] (and valid? (= "123" (:iss payload))))
+      (provided (code/app-id) => "123" (code/app-private-key) => (pkcs8-pem kp))))
+
+  (fact "also accepts a PKCS#1 key, the format GitHub issues App keys in"
+    (let [kp (rsa-keypair)]
+      (jwt-verifies? (code/app-jwt) (.getPublic kp)) => (fn [r] (:valid? r))
+      (provided (code/app-id) => "123" (code/app-private-key) => (pkcs1-pem kp)))))
+
+(facts "about github auth config"
+  (fact "app-configured? requires both an id and a private key"
+    (code/app-configured?) => true
+    (provided (code/app-id) => "123" (code/app-private-key) => "KEY"))
+
+  (fact "app-configured? is false without a private key"
+    (code/app-configured?) => false
+    (provided (code/app-id) => "123" (code/app-private-key) => nil))
+
+  (fact "github-auth-configured? is satisfied by a PAT alone"
+    (code/github-auth-configured?) => true
+    (provided (code/app-configured?) => false (code/github-pat) => "tok"))
+
+  (fact "github-auth-configured? is satisfied by an App alone"
+    (code/github-auth-configured?) => true
+    (provided (code/app-configured?) => true))
+
+  (fact "github-auth-configured? is false with neither"
+    (code/github-auth-configured?) => false
+    (provided (code/app-configured?) => false (code/github-pat) => nil)))
+
+(facts "about github-token resolution"
+  (fact "uses the static PAT when no App is configured"
+    (code/github-token "yetibot" "core") => "pat"
+    (provided (code/app-configured?) => false (code/github-pat) => "pat"))
+
+  (fact "mints an installation token when an App is configured"
+    (code/github-token "yetibot" "core") => "ghs_installation"
+    (provided (code/app-configured?) => true
+              (code/installation-token "yetibot" "core") => "ghs_installation")))
+
+(facts "about installation-token"
+  (fact "exchanges an app JWT for an installation access token"
+    (code/installation-token "yetibot" "core") => "ghs_abc"
+    (provided
+     (code/app-jwt) => "jwt"
+     (code/installation-id "jwt" "yetibot" "core") => 42
+     (client/post "https://api.github.com/app/installations/42/access_tokens"
+                  anything)
+     => {:status 201 :body {:token "ghs_abc"}}))
+
+  (fact "throws when the token exchange fails"
+    (code/installation-token "yetibot" "core") => (throws clojure.lang.ExceptionInfo)
+    (provided
+     (code/app-jwt) => "jwt"
+     (code/installation-id "jwt" "yetibot" "core") => 42
+     (client/post anything anything) => {:status 401 :body {:message "Bad credentials"}})))
+
 (facts "about code-cmd guards"
   (fact "complains when gemini is not configured"
     (code/code-cmd {:match ["code yetibot/core x" "yetibot/core" "x"]})
     => (contains "Gemini is not configured")
-    (provided (code/gemini-key) => nil
-              (code/github-token) => "tok"))
+    (provided (code/gemini-key) => nil))
 
-  (fact "complains when no github token is configured"
+  (fact "complains when no github auth is configured"
     (code/code-cmd {:match ["code yetibot/core x" "yetibot/core" "x"]})
-    => (contains "No GitHub token configured")
+    => (contains "No GitHub auth configured")
     (provided (code/gemini-key) => "key"
-              (code/github-token) => nil))
+              (code/github-auth-configured?) => false))
 
   (fact "reports the PR url on success"
     (code/code-cmd {:match ["code yetibot/core increase banana budget"
                             "yetibot/core" "increase banana budget"]})
     => (contains "https://github.com/yetibot/core/pull/7")
     (provided (code/gemini-key) => "key"
-              (code/github-token) => "tok"
+              (code/github-auth-configured?) => true
+              (code/github-token "yetibot" "core") => "tok"
               (code/file-pr anything)
               => {:html_url "https://github.com/yetibot/core/pull/7"}))
 
@@ -114,6 +210,7 @@
     (code/code-cmd {:match ["code yetibot/core nothing" "yetibot/core" "nothing"]})
     => (contains "didn't make any changes")
     (provided (code/gemini-key) => "key"
-              (code/github-token) => "tok"
+              (code/github-auth-configured?) => true
+              (code/github-token "yetibot" "core") => "tok"
               (code/file-pr anything)
               =throws=> (ex-info "Gemini did not make any changes" {:type :no-changes}))))

--- a/test/yetibot/core/test/commands/code.clj
+++ b/test/yetibot/core/test/commands/code.clj
@@ -1,0 +1,119 @@
+(ns yetibot.core.test.commands.code
+  (:require
+   [midje.sweet :refer [fact facts => anything throws =throws=>]]
+   [midje.checkers :refer [contains]]
+   [clojure.string :as string]
+   [clj-http.client :as client]
+   [yetibot.core.commands.code :as code]))
+
+(facts "about parse-repo"
+  (fact "splits owner/repo"
+    (code/parse-repo "yetibot/core") => ["yetibot" "core"])
+
+  (fact "trims whitespace"
+    (code/parse-repo "  yetibot/core  ") => ["yetibot" "core"])
+
+  (fact "uses default org for a bare repo name"
+    (code/parse-repo "core") => ["yetibot" "core"]
+    (provided (code/default-org) => "yetibot")))
+
+(facts "about authed-clone-url"
+  (fact "embeds the token for auth"
+    (code/authed-clone-url "secret" "yetibot" "core") =>
+    "https://x-access-token:secret@github.com/yetibot/core.git"))
+
+(facts "about branch-name"
+  (fact "is namespaced and unique-ish"
+    (code/branch-name) => #(string/starts-with? % "yetibot/code-")))
+
+(facts "about pr-title"
+  (fact "capitalizes and collapses whitespace"
+    (code/pr-title "increase   banana budget") => "Increase banana budget")
+
+  (fact "truncates very long instructions"
+    (count (code/pr-title (apply str (repeat 200 "x")))) => 72)
+
+  (fact "marks truncated titles with an ellipsis"
+    (string/ends-with? (code/pr-title (apply str (repeat 200 "x"))) "...") => true)
+
+  (fact "handles blank instruction"
+    (code/pr-title "   ") => "Yetibot change"))
+
+(facts "about pr-body"
+  (fact "includes the instruction and model"
+    (code/pr-body "do a thing" "I did the thing") =>
+    (contains "do a thing"))
+
+  (fact "embeds gemini output when present"
+    (code/pr-body "x" "some output") => (contains "some output")))
+
+(facts "about redact"
+  (fact "strips an embedded github token from a clone url"
+    (code/redact "git clone https://x-access-token:supersecret@github.com/yetibot/core.git")
+    => "git clone https://x-access-token:***@github.com/yetibot/core.git")
+
+  (fact "leaves token-free strings untouched"
+    (code/redact "nothing to redact here") => "nothing to redact here")
+
+  (fact "tolerates nil"
+    (code/redact nil) => nil))
+
+(facts "about run-gemini"
+  (fact "invokes the configured cli with model, yolo, and prompt, passing the API key in env"
+    (code/run-gemini "/tmp/repo" "increase banana budget") => {:exit 0 :out "done" :err ""}
+    (provided
+     (code/cli-bin) => "gemini"
+     (code/gemini-key) => "test-key"
+     (code/check-sh {:dir "/tmp/repo" :env {"GEMINI_API_KEY" "test-key"}}
+                    "gemini" "--model" "gemini-2.5-pro" "--yolo"
+                    "--prompt" anything)
+     => {:exit 0 :out "done" :err ""})))
+
+(facts "about create-pull-request"
+  (fact "returns the PR body on success and includes auth + payload"
+    (code/create-pull-request "tok" "yetibot" "core"
+                              {:title "T" :body "B" :head "h" :base "master"})
+    => {:html_url "https://github.com/yetibot/core/pull/1"}
+    (provided
+     (client/post
+      "https://api.github.com/repos/yetibot/core/pulls"
+      anything)
+     => {:status 201 :body {:html_url "https://github.com/yetibot/core/pull/1"}}))
+
+  (fact "throws on a non-2xx response"
+    (code/create-pull-request "tok" "yetibot" "core"
+                              {:title "T" :body "B" :head "h" :base "master"})
+    => (throws clojure.lang.ExceptionInfo)
+    (provided
+     (client/post anything anything)
+     => {:status 422 :body {:message "Validation Failed"}})))
+
+(facts "about code-cmd guards"
+  (fact "complains when gemini is not configured"
+    (code/code-cmd {:match ["code yetibot/core x" "yetibot/core" "x"]})
+    => (contains "Gemini is not configured")
+    (provided (code/gemini-key) => nil
+              (code/github-token) => "tok"))
+
+  (fact "complains when no github token is configured"
+    (code/code-cmd {:match ["code yetibot/core x" "yetibot/core" "x"]})
+    => (contains "No GitHub token configured")
+    (provided (code/gemini-key) => "key"
+              (code/github-token) => nil))
+
+  (fact "reports the PR url on success"
+    (code/code-cmd {:match ["code yetibot/core increase banana budget"
+                            "yetibot/core" "increase banana budget"]})
+    => (contains "https://github.com/yetibot/core/pull/7")
+    (provided (code/gemini-key) => "key"
+              (code/github-token) => "tok"
+              (code/file-pr anything)
+              => {:html_url "https://github.com/yetibot/core/pull/7"}))
+
+  (fact "reports a friendly message when gemini makes no changes"
+    (code/code-cmd {:match ["code yetibot/core nothing" "yetibot/core" "nothing"]})
+    => (contains "didn't make any changes")
+    (provided (code/gemini-key) => "key"
+              (code/github-token) => "tok"
+              (code/file-pr anything)
+              =throws=> (ex-info "Gemini did not make any changes" {:type :no-changes}))))


### PR DESCRIPTION
## What

Brings the Gemini stack into core so it lives alongside the rest of Yetibot's commands:

- `yetibot.core.util.gemini` — Gemini API client + monthly image budget
- `yetibot.core.commands.banana` / `bameme` — image/meme generation
- `yetibot.core.commands.code` — Gemini-CLI files a PR against a GitHub repo
- `yetibot.core.db.image-budget` — budget table
- `yetibot.core.webapp.routes.images` — serves generated images

These previously lived in the `yetibot` app; this is the canonical home.

## Cleanups bundled in

- **Single Gemini config.** All settings live under `[:gemini]` sharing one API key (`YB_GEMINI_KEY`) instead of a separate `[:gemini :api :key]`. No more duplicate token.
- **No model env var.** The model is fixed per use (`gemini-3.1-flash-image-preview` for images, `gemini-2.5-pro` for `code`); dropped the `YB_GEMINI_MODEL` override.
- **Single GitHub token.** `code` reuses the existing `[:github :token]` (`YB_GITHUB_TOKEN`); dropped the duplicate `[:features :github :token]` fallback.
- **No-change runs are not errors.** When the Gemini CLI makes no changes, `code` now logs at `info` (it's an expected outcome) instead of `error`.
- **Direct route wiring.** The webapp handler now requires `image-routes` directly, replacing the dynamic resolve shim that reached into the app namespace.

## Tests

`test/yetibot/core/test/commands/code.clj` ported; all 21 checks pass. `lein check` compiles cleanly.

## Follow-up

A companion yetibot PR removes these files from the app and bumps `yetibot/core` to the version this publishes.