### PR TITLE
agent: thin relay over a headless Gemini agent (gh+git), fix No-results

### DIFF
--- a/src/yetibot/core/commands/agent.clj
+++ b/src/yetibot/core/commands/agent.clj
@@ -1,19 +1,19 @@
 (ns yetibot.core.commands.agent
-  "A meme-loving coding agent. `agent <prompt>` figures out which GitHub repos
-   the request touches, clones each, drives the Gemini CLI to make the change,
-   and opens a pull request per repo — narrating progress in a chat thread with
-   a quirky grug/caveman persona.
+  "A meme-loving coding agent. `agent <prompt>` hands the request to the Gemini
+   CLI running headlessly as an autonomous agent: Gemini uses the authenticated
+   `gh` CLI and `git` to find the right repo(s), make the change, and open pull
+   requests itself. Yetibot's job is just to run it and relay what it's doing,
+   live, into a chat thread — in a quirky grug/caveman persona.
 
    On Discord the agent works inside a thread spun off the triggering message,
-   so a team can keep replying in that thread and re-trigger `agent` to iterate;
-   the whole thread is fed back as context each time. On other adapters it
-   degrades gracefully to plain in-channel replies.
+   so a team can keep replying and re-trigger `agent` to iterate; the thread is
+   fed back as context. On other adapters it degrades to plain in-channel
+   replies.
 
-   GitHub auth is either a static token (PAT) or a GitHub App, whichever is
-   configured — an App is preferred since it mints short-lived, repo-scoped
-   installation tokens instead of relying on a long-lived personal token."
+   GitHub auth is a GitHub App (preferred) or a static token; either is handed
+   to Gemini as GH_TOKEN so its `gh`/`git` calls are authenticated."
   (:require
-   [clojure.java.shell :as shell]
+   [clojure.java.io :as io]
    [clojure.spec.alpha :as s]
    [clojure.string :as string]
    [clojure.data.json :as json]
@@ -36,17 +36,11 @@
 ;;
 ;;   YB_GEMINI_KEY          - Gemini API key (required)
 ;;   YB_GEMINI_CLI          - path to the gemini CLI binary (default "gemini")
-;;   YB_GEMINI_DEFAULT_ORG  - org used for repo discovery / bare repo names
 ;;
 ;; GitHub auth, in order of preference:
-;;
-;;   GitHub App (short-lived, repo-scoped installation tokens):
-;;     YB_GITHUB_APP_ID              - the App's ID
-;;     YB_GITHUB_APP_PRIVATE_KEY     - the App's PEM private key
-;;     YB_GITHUB_APP_INSTALLATION_ID - optional; auto-resolved per repo if unset
-;;
-;;   Static token:
-;;     YB_GITHUB_TOKEN               - a personal access token
+;;   GitHub App: YB_GITHUB_APP_ID + YB_GITHUB_APP_PRIVATE_KEY
+;;               (+ optional YB_GITHUB_APP_INSTALLATION_ID)
+;;   Static token: YB_GITHUB_TOKEN
 ;; ---------------------------------------------------------------------------
 
 (s/def ::str string?)
@@ -60,7 +54,6 @@
 
 (defn gemini-key [] (config-str [:gemini :key]))
 (defn cli-bin [] (or (config-str [:gemini :cli]) "gemini"))
-(defn default-org [] (or (config-str [:gemini :default-org]) "yetibot"))
 
 (defn github-pat [] (config-str [:github :token]))
 
@@ -87,187 +80,53 @@
                 (github-auth-configured?))))
 
 ;; ---------------------------------------------------------------------------
-;; Persona — grug/caveman/meme voice for the agent's chat messages only. The
-;; code Gemini writes stays clean; this just flavors what the bot says.
+;; Persona — grug/caveman/meme voice for the agent's chat messages only.
 ;; ---------------------------------------------------------------------------
 
 (defn say-thinking [prompt]
-  (str "🦴 grug see request: _" (string/trim prompt) "_\n"
-       "grug sharpen rock, find repos... 🧠⏳"))
+  (str "🦴 grug get request: _" (string/trim prompt) "_\n"
+       "grug wake gemini brain 🧠⚡ — grug narrate as grug work..."))
 
-(defn say-plan [repos]
-  (str "🪓 grug smash these repos: " (string/join ", " (map #(str "`" % "`") repos))
-       ". much code, very PR. 🚀"))
+(defn say-progress [chunk]
+  (str "🧠 " (str "```\n" (string/trim chunk) "\n```")))
 
-(defn say-done [results]
-  (let [ok (filter :url results)
-        bad (remove :url results)]
-    (str "✅ grug done! "
-         (if (seq ok) "much wow 🎉 stonks 📈\n" "but grug make no fire this time 🔥\n")
-         (string/join "\n"
-                      (for [{:keys [repo url error]} results]
-                        (if url
-                          (str "• `" repo "` → " url)
-                          (str "• `" repo "` → 💥 " error))))
-         (when (and (seq ok) (seq bad)) "\ngrug do best. some rock too hard. 🪨"))))
-
-(defn say-nothing [repos]
-  (str "🤔 grug look at " (string/join ", " (map #(str "`" %"`") repos))
-       " but see no change to make. tell grug clearer, grug try again. 🦴"))
+(defn say-done [pr-urls]
+  (if (seq pr-urls)
+    (str "✅ grug done! much PR, very wow 🎉 stonks 📈\n"
+         (string/join "\n" (map #(str "• " %) pr-urls)))
+    (str "✅ grug done! 🦴 (no PR this time — maybe grug just answer above)")))
 
 (defn say-broken [msg]
-  (str "💥 grug hit big rock: " msg "\ngrug sad. 😵 try again maybe?"))
+  (str "💥 grug hit big rock: " msg "\ngrug sad 😵 — see log above maybe."))
 
 (defn say-unconfigured []
-  (str "🪨 grug brain not plugged in. need Gemini key + GitHub auth (App or token). grug wait. 😴"))
-
-(defn say-no-repos []
-  (str "🤷 grug no can tell which repo to smash. say it like `agent yetibot/core <change>`. 🦴"))
+  (str "🪨 grug brain not plugged in. need Gemini key + GitHub auth (App or token). grug wait 😴"))
 
 ;; ---------------------------------------------------------------------------
-;; Shell helpers
+;; Safety
 ;; ---------------------------------------------------------------------------
-
-(defn sh*
-  "Run a shell command, optionally in :dir with extra :env vars merged on top of
-   the current environment. Returns the clojure.java.shell result map."
-  [{:keys [dir env]} & args]
-  (let [full-env (when (seq env)
-                   (merge (into {} (System/getenv)) env))
-        opts (cond-> []
-               dir (conj :dir dir)
-               full-env (conj :env full-env))
-        result (apply shell/sh (concat args opts))]
-    (debug "sh" (pr-str (vec args)) "exit" (:exit result))
-    result))
 
 (defn redact
-  "Strip embedded credentials (e.g. a token in a clone URL) from a string so
-   they never reach chat output or logs."
+  "Strip embedded credentials (e.g. a token in a URL) from a string before it
+   reaches chat or logs."
   [s]
   (when s
     (-> s
         (string/replace #"(://[^:/@\s]+:)[^@\s]+(@)" "$1***$2")
-        (string/replace #"(://)[^:/@\s]+(@)" "$1***$2"))))
-
-(defn check-sh
-  "Like sh* but throws ex-info with captured (credential-redacted) output when
-   the command fails."
-  [ctx & args]
-  (let [{:keys [exit out err] :as result} (apply sh* ctx args)]
-    (when-not (zero? exit)
-      (throw (ex-info (redact (format "command failed (exit %s): %s\n%s"
-                                      exit (string/join " " args)
-                                      (or (not-empty (string/trim (str err)))
-                                          (string/trim (str out)))))
-                      {:exit exit
-                       :out (redact out)
-                       :err (redact err)
-                       :args (mapv redact args)})))
-    result))
-
-;; ---------------------------------------------------------------------------
-;; Pure-ish helpers
-;; ---------------------------------------------------------------------------
-
-(defn parse-repo
-  "Parse `owner/repo` or bare `repo` (using the default org) into [owner repo]."
-  [repo-arg]
-  (let [parts (-> repo-arg string/trim (string/split #"/"))]
-    (if (>= (count parts) 2)
-      [(first parts) (second parts)]
-      [(default-org) (first parts)])))
-
-(defn authed-clone-url [token owner repo]
-  (format "https://x-access-token:%s@github.com/%s/%s.git" token owner repo))
-
-(defn branch-name []
-  (str "yetibot/agent-" (System/currentTimeMillis)))
-
-(defn pr-title [instruction]
-  (let [one-line (-> instruction string/trim (string/replace #"\s+" " "))
-        capped (if (> (count one-line) 72) (str (subs one-line 0 69) "...") one-line)]
-    (if (seq capped)
-      (str (string/upper-case (subs capped 0 1)) (subs capped 1))
-      "Yetibot change")))
-
-(defn pr-body [instruction gemini-out]
-  (str "Requested via Yetibot:\n\n> " (string/trim instruction) "\n\n"
-       "This change was authored by the Gemini CLI (`" model "`) "
-       "and opened automatically by Yetibot 🤖.\n\n"
-       (when-not (string/blank? gemini-out)
-         (str "<details><summary>Gemini output</summary>\n\n```\n"
-              (string/trim gemini-out)
-              "\n```\n\n</details>\n"))))
+        (string/replace #"(://)[^:/@\s]+(@)" "$1***$2")
+        (string/replace #"gh[pousr]_[A-Za-z0-9]{20,}" "***"))))
 
 (defn- temp-dir []
   (.toFile (Files/createTempDirectory "yetibot-agent" (make-array FileAttribute 0))))
 
-(defn default-branch [repo-dir]
-  (let [{:keys [exit out]} (sh* {:dir repo-dir}
-                                "git" "rev-parse" "--abbrev-ref" "origin/HEAD")]
-    (if (zero? exit)
-      (-> out string/trim (string/replace #"^origin/" ""))
-      "master")))
-
-(defn working-tree-dirty? [repo-dir]
-  (-> (sh* {:dir repo-dir} "git" "status" "--porcelain") :out string/blank? not))
+(defn pr-urls
+  "GitHub pull request URLs mentioned in text, de-duplicated."
+  [text]
+  (->> (re-seq #"https://github\.com/[\w.-]+/[\w.-]+/pull/\d+" (or text ""))
+       distinct vec))
 
 ;; ---------------------------------------------------------------------------
-;; Gemini
-;; ---------------------------------------------------------------------------
-
-(defn build-gemini-prompt
-  "Wrap the user's instruction with guidance so the CLI edits files directly.
-   Optional thread context gives the agent the prior conversation to work from."
-  [instruction context]
-  (str "You are an automated coding agent working in a cloned git repository. "
-       "Make the following change directly to the files in this repository, "
-       "keeping the change minimal and focused.\n\n"
-       "The `gh` CLI is installed and authenticated (GH_TOKEN is set) — use it "
-       "freely for read-only GitHub operations that help you make a correct "
-       "change: reading issues and PRs, code search, viewing checks/CI, repo "
-       "metadata, etc. Do NOT commit, push, or open a pull request yourself "
-       "(neither with git nor `gh`) — only edit files; Yetibot handles the PR. "
-       "When you are done, briefly summarize what you changed.\n\n"
-       (when-not (string/blank? context)
-         (str "Conversation context so far:\n" (string/trim context) "\n\n"))
-       "Change to make:\n" (string/trim instruction)))
-
-(defn run-gemini
-  "Invoke the Gemini CLI in repo-dir to perform the coding instruction. Trusts
-   the workspace explicitly so it runs non-interactively, and exports GH_TOKEN
-   so the agent can use the authenticated `gh` CLI for read-only GitHub lookups."
-  [repo-dir instruction context token]
-  (info "running gemini" (cli-bin) "model" model)
-  (check-sh {:dir repo-dir
-             :env {"GEMINI_API_KEY" (gemini-key)
-                   "GEMINI_CLI_TRUST_WORKSPACE" "true"
-                   "GH_TOKEN" (or token "")}}
-            (cli-bin)
-            "--model" model
-            "--yolo"
-            "--prompt" (build-gemini-prompt instruction context)))
-
-(defn gemini-text
-  "One-shot Gemini text completion via the REST API. Used for lightweight
-   reasoning (e.g. picking repos). Returns the model's text, or nil on failure."
-  [prompt]
-  (try
-    (let [{:keys [status body]}
-          (client/post
-           (format "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s"
-                   model (gemini-key))
-           {:content-type :json :as :json :coerce :always :throw-exceptions false
-            :body (json/write-str {:contents [{:parts [{:text prompt}]}]})})]
-      (when (<= 200 status 299)
-        (-> body :candidates first :content :parts first :text)))
-    (catch Exception e
-      (warn "gemini-text failed:" (.getMessage e))
-      nil)))
-
-;; ---------------------------------------------------------------------------
-;; GitHub
+;; GitHub auth — enough to mint a token to hand Gemini as GH_TOKEN
 ;; ---------------------------------------------------------------------------
 
 (def ^:private api-base "https://api.github.com")
@@ -335,147 +194,88 @@
                            (seg {:iat (- now 60) :exp (+ now (* 9 60)) :iss (app-id)}))]
     (str signing-input "." (rs256 signing-input (app-private-key)))))
 
-(defn installation-id [jwt-token owner repo]
+(defn any-installation-id
+  "An installation id for the App: the configured one, else its first install."
+  [jwt-token]
   (or (config-str [:github :app :installation-id])
-      (-> (gh-get (format "%s/repos/%s/%s/installation" api-base owner repo)
-                  (str "Bearer " jwt-token))
-          (gh-ok "GitHub App installation lookup")
-          :id)))
-
-(defn installation-token [owner repo]
-  (let [jwt-token (app-jwt)
-        id (installation-id jwt-token owner repo)]
-    (-> (client/post (format "%s/app/installations/%s/access_tokens" api-base id)
-                     {:headers (gh-headers (str "Bearer " jwt-token))
-                      :as :json :coerce :always :throw-exceptions false})
-        (gh-ok "GitHub App token exchange")
-        :token)))
+      (-> (gh-get (str api-base "/app/installations") (str "Bearer " jwt-token))
+          (gh-ok "list app installations")
+          first :id)))
 
 (defn github-token
-  "Resolve a GitHub token for owner/repo: a freshly-minted App installation
-   token when an App is configured, otherwise the static PAT."
-  [owner repo]
+  "A token to hand Gemini as GH_TOKEN: a freshly-minted App installation token
+   (scoped to everything the App can reach), or the static PAT."
+  []
   (if (app-configured?)
-    (installation-token owner repo)
+    (let [jwt-token (app-jwt)]
+      (-> (client/post (format "%s/app/installations/%s/access_tokens"
+                               api-base (any-installation-id jwt-token))
+                       {:headers (gh-headers (str "Bearer " jwt-token))
+                        :as :json :coerce :always :throw-exceptions false})
+          (gh-ok "GitHub App token exchange")
+          :token))
     (github-pat)))
 
-(defn list-org-repos
-  "Names (owner/repo) of the org's repos, for repo discovery. Best-effort."
-  [org]
-  (try
-    (let [auth (if (app-configured?)
-                 (str "Bearer " (app-jwt))
-                 (str "Bearer " (github-pat)))]
-      (->> (gh-get (format "%s/orgs/%s/repos?per_page=100&type=all" api-base org) auth)
-           (#(gh-ok % "list org repos"))
-           (map :full_name)
-           (remove nil?)))
-    (catch Exception e
-      (warn "list-org-repos failed:" (.getMessage e))
-      [])))
-
-(defn create-pull-request [token owner repo {:keys [title body head base]}]
-  (let [{:keys [status body]}
-        (client/post (format "%s/repos/%s/%s/pulls" api-base owner repo)
-                     {:headers (gh-headers (str "Bearer " token))
-                      :content-type :json :as :json :coerce :always
-                      :throw-exceptions false
-                      :body (json/write-str {:title title :body body
-                                             :head head :base base})})]
-    (debug "create-pull-request status" status)
-    (if (<= 200 status 299)
-      body
-      (throw (ex-info (str "GitHub PR creation failed: " (or (:message body) status))
-                      {:status status :body body})))))
-
 ;; ---------------------------------------------------------------------------
-;; Repo discovery
+;; The agent prompt — Gemini does everything via gh + git
 ;; ---------------------------------------------------------------------------
 
-(defn explicit-repos
-  "owner/repo tokens written literally in the prompt."
-  [prompt]
-  (->> (re-seq #"\b[\w.-]+/[\w.-]+\b" prompt) distinct vec))
+(defn build-agent-prompt [request context]
+  (str "You are Yetibot's autonomous coding agent, running non-interactively in "
+       "an empty scratch directory. You have a shell with two key tools:\n"
+       "- `gh`: the GitHub CLI, already authenticated (GH_TOKEN is set). Use it "
+       "for everything GitHub — finding repos (`gh search repos`, `gh repo list`), "
+       "reading code/issues/PRs, cloning (`gh repo clone`), and opening pull "
+       "requests (`gh pr create`).\n"
+       "- `git`: for local changes.\n\n"
+       "Fulfill the user's request end to end:\n"
+       "1. Work out which repo(s) are involved (use gh to search if unsure).\n"
+       "2. Clone what you need into the current directory.\n"
+       "3. Before committing, set: git config user.name 'Yetibot' and "
+       "git config user.email 'yetibot@yetibot.com'.\n"
+       "4. Make the change on a new branch, keeping it minimal and focused.\n"
+       "5. Commit, push, and open a pull request with `gh pr create` against the "
+       "default branch. Output the PR URL.\n"
+       "6. If the request is just a question (no code change needed), answer it "
+       "concisely and do NOT open a PR.\n\n"
+       "Narrate what you're doing in short steps as you go. End with a brief "
+       "summary including any pull request URLs.\n\n"
+       (when-not (string/blank? context)
+         (str "Conversation so far:\n" (string/trim context) "\n\n"))
+       "Request:\n" (string/trim request)))
 
-(defn discover-repos
-  "Decide which repos the request touches: explicit owner/repo tokens if present,
-   otherwise ask Gemini to pick from the org's repo list."
-  [prompt]
-  (let [explicit (explicit-repos prompt)]
-    (if (seq explicit)
-      explicit
-      (let [repos (list-org-repos (default-org))]
-        (if (empty? repos)
-          []
-          (let [answer (gemini-text
-                        (str "From this list of GitHub repos:\n"
-                             (string/join "\n" repos)
-                             "\n\nWhich repos must be changed to fulfill this request? "
-                             "Reply with ONLY a comma-separated list of owner/repo "
-                             "from the list above, nothing else.\n\nRequest: " prompt))]
-            (->> (string/split (or answer "") #"[,\n]")
-                 (map string/trim)
-                 (filter (set repos))
-                 distinct vec)))))))
+(defn run-gemini-agent
+  "Run the Gemini CLI as an autonomous agent in `workdir`, streaming combined
+   stdout/stderr line-by-line to `on-chunk` (called with redacted text chunks).
+   Returns {:exit n :out <full output>}."
+  [workdir request context token on-chunk]
+  (let [pb (doto (ProcessBuilder. [(cli-bin) "--yolo" "--model" model
+                                   "--prompt" (build-agent-prompt request context)])
+             (.directory (io/file workdir))
+             (.redirectErrorStream true))]
+    (doto (.environment pb)
+      (.put "GEMINI_API_KEY" (gemini-key))
+      (.put "GEMINI_CLI_TRUST_WORKSPACE" "true")
+      (.put "GH_TOKEN" (or token "")))
+    (info "running gemini agent" (cli-bin) "in" (str workdir))
+    (let [proc (.start pb)
+          full (StringBuilder.)]
+      (with-open [rdr (io/reader (.getInputStream proc))]
+        (loop [buf (StringBuilder.)]
+          (let [line (.readLine rdr)]
+            (cond
+              (nil? line)
+              (when (pos? (.length buf)) (on-chunk (redact (str buf))))
 
-;; ---------------------------------------------------------------------------
-;; Orchestration
-;; ---------------------------------------------------------------------------
+              (>= (.length buf) 1200)
+              (do (on-chunk (redact (str buf)))
+                  (recur (doto (StringBuilder.) (.append line) (.append "\n"))))
 
-(defn file-pr
-  "End to end for one repo: clone, rebase on trunk, run Gemini, commit, push,
-   open PR. Returns the GitHub PR map (with :html_url) or throws."
-  [{:keys [owner repo instruction context token]}]
-  (let [dir (temp-dir)
-        repo-dir dir
-        ctx {:dir repo-dir}
-        clone-url (authed-clone-url token owner repo)
-        branch (branch-name)]
-    (try
-      (info "cloning" (format "%s/%s" owner repo) "into" (str dir))
-      (check-sh {} "git" "clone" "--depth" "50" clone-url (str repo-dir))
-      (check-sh ctx "git" "config" "user.name" "Yetibot")
-      (check-sh ctx "git" "config" "user.email" "yetibot@yetibot.com")
-      (let [trunk (default-branch repo-dir)]
-        (info "trunk is" trunk)
-        (check-sh ctx "git" "checkout" trunk)
-        (check-sh ctx "git" "fetch" "origin" trunk)
-        (check-sh ctx "git" "pull" "--rebase" "origin" trunk)
-        (check-sh ctx "git" "checkout" "-b" branch)
-        (let [gemini-result (run-gemini repo-dir instruction context token)]
-          (when-not (working-tree-dirty? repo-dir)
-            (throw (ex-info "Gemini did not make any changes" {:type :no-changes})))
-          (check-sh ctx "git" "add" "-A")
-          (check-sh ctx "git" "commit" "-m" (pr-title instruction))
-          (check-sh ctx "git" "push" "-u" "origin" branch)
-          (create-pull-request token owner repo
-                               {:title (pr-title instruction)
-                                :body (pr-body instruction (:out gemini-result))
-                                :head branch
-                                :base trunk})))
-      (finally
-        (try (sh* {} "rm" "-rf" (str dir))
-             (catch Exception e (warn "failed to clean up" (str dir) e)))))))
-
-(defn run-repo
-  "file-pr for one `owner/repo`, captured into a result map (never throws)."
-  [repo-full instruction context]
-  (let [[owner repo] (parse-repo repo-full)
-        full (str owner "/" repo)]
-    (try
-      (let [token (github-token owner repo)
-            {:keys [html_url]} (file-pr {:owner owner :repo repo
-                                         :instruction instruction
-                                         :context context :token token})]
-        {:repo full :url html_url})
-      (catch clojure.lang.ExceptionInfo e
-        (if (= :no-changes (:type (ex-data e)))
-          {:repo full :no-changes true}
-          (do (error "agent: failed for" full e)
-              {:repo full :error (.getMessage e)})))
-      (catch Exception e
-        (error "agent: failed for" full e)
-        {:repo full :error (.getMessage e)}))))
+              :else
+              (do (.append full line) (.append full "\n")
+                  (.append buf line) (.append buf "\n")
+                  (recur buf))))))
+      {:exit (.waitFor proc) :out (str full)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Discord thread plumbing (guarded; degrades to plain replies elsewhere)
@@ -489,18 +289,13 @@
 
 (defn- start-thread!
   "Spin a Discord thread off the triggering message; returns the thread channel
-   id, or the original channel id if threading isn't possible (e.g. already in a
-   thread)."
+   id, or the original channel id if threading isn't possible."
   [channel-id message-id title]
   (or (try
         (:id @(discord/start-thread-with-message!
                (rest-conn) channel-id message-id (subs title 0 (min 90 (count title))) 1440))
         (catch Exception e (debug "start-thread! fell back:" (.getMessage e)) nil))
       channel-id))
-
-(defn- delete-msg! [channel-id message-id]
-  (try @(discord/delete-message! (rest-conn) channel-id message-id)
-       (catch Exception e (debug "delete-msg! failed:" (.getMessage e)))))
 
 (defn- thread-context
   "Recent conversation in the channel/thread, oldest-first, as plain text."
@@ -517,33 +312,39 @@
 ;; Command
 ;; ---------------------------------------------------------------------------
 
+(def ^:private max-progress-msgs 20)
+
 (defn run-agent
-  "The async body: figure out repos, run them, narrate progress in `target`.
-   `ack-id` (if any) is the thinking message to delete before the final reply."
-  [{:keys [prompt target ack-id discord?]}]
+  "Async body: mint a token, run Gemini as an autonomous agent in a scratch dir,
+   relay its progress into `target`, and post a final summary with PR links."
+  [{:keys [request target context-channel on-discord]}]
   (binding [chat/*target* target]
-    (try
-      (let [context (when discord? (thread-context target))
-            repos (discover-repos prompt)]
-        (if (empty? repos)
-          (chat/send-msg (say-no-repos))
-          (do
-            (chat/send-msg (say-plan repos))
-            (let [results (mapv #(run-repo % prompt context) repos)]
-              (when (and discord? ack-id) (delete-msg! target ack-id))
-              (cond
-                (some :url results) (chat/send-msg (say-done results))
-                (every? :no-changes results) (chat/send-msg (say-nothing repos))
-                :else (chat/send-msg (say-done results)))))))
-      (catch Exception e
-        (error "agent command failed" e)
-        (when (and discord? ack-id) (delete-msg! target ack-id))
-        (chat/send-msg (say-broken (.getMessage e)))))))
+    (let [dir (temp-dir)
+          posted (atom 0)]
+      (try
+        (let [context (when on-discord (thread-context context-channel))
+              token (github-token)
+              relay (fn [chunk]
+                      (when (and (not (string/blank? chunk))
+                                 (< @posted max-progress-msgs))
+                        (swap! posted inc)
+                        (chat/send-msg (say-progress chunk))))
+              {:keys [exit out]} (run-gemini-agent dir request context token relay)]
+          (cond
+            (pos? exit) (chat/send-msg (say-broken (str "gemini exited " exit)))
+            :else (chat/send-msg (say-done (pr-urls out)))))
+        (catch Exception e
+          (error "agent command failed" e)
+          (chat/send-msg (say-broken (.getMessage e))))
+        (finally
+          (try (when (.exists dir)
+                 (doseq [f (reverse (file-seq dir))] (.delete f)))
+               (catch Exception e (warn "cleanup failed" (str dir) e))))))))
 
 (defn agent-cmd
-  "agent <prompt> # grug figures out the repos, makes the changes, opens PRs"
+  "agent <prompt> # grug hands it to Gemini, which uses gh+git to make a PR"
   {:yb/cat #{:util}}
-  [{[_ prompt] :match chat-source :chat-source}]
+  [{[_ request] :match chat-source :chat-source}]
   (if-not (configured?)
     (say-unconfigured)
     (let [adapter chat/*adapter*
@@ -553,16 +354,16 @@
           on-discord (discord?)
           ;; on Discord, work inside a thread off the triggering message
           target (if (and on-discord channel msg-id)
-                   (start-thread! channel msg-id (pr-title prompt))
-                   chat/*target*)
-          ack-id (binding [chat/*target* target]
-                   (:id (chat/send-msg (say-thinking prompt))))]
-      ;; do the slow work off-thread; messages post out of band into `target`
+                   (start-thread! channel msg-id request)
+                   chat/*target*)]
+      (binding [chat/*target* target] (chat/send-msg (say-thinking request)))
       (future
         (binding [chat/*adapter* adapter]
-          (run-agent {:prompt prompt :target target
-                      :ack-id ack-id :discord? on-discord})))
-      nil)))
+          (run-agent {:request request :target target
+                      :context-channel channel :on-discord on-discord})))
+      ;; everything is narrated out of band; suppress the framework's reply so it
+      ;; doesn't post "No results" into the parent channel.
+      (chat/suppress {}))))
 
 ;; Register only when Gemini + GitHub auth are configured.
 (when (configured?)

--- a/test/yetibot/core/test/commands/agent.clj
+++ b/test/yetibot/core/test/commands/agent.clj
@@ -1,6 +1,6 @@
 (ns yetibot.core.test.commands.agent
   (:require
-   [midje.sweet :refer [fact facts => anything throws =throws=>]]
+   [midje.sweet :refer [fact facts => anything]]
    [midje.checkers :refer [contains]]
    [clojure.string :as string]
    [clojure.data.json :as json]
@@ -10,125 +10,43 @@
    [java.security KeyPairGenerator Signature]
    [java.util Arrays Base64]))
 
-(facts "about parse-repo"
-  (fact "splits owner/repo"
-    (agent/parse-repo "yetibot/core") => ["yetibot" "core"])
-  (fact "uses default org for a bare repo name"
-    (agent/parse-repo "core") => ["yetibot" "core"]
-    (provided (agent/default-org) => "yetibot")))
-
-(facts "about explicit-repos"
-  (fact "extracts owner/repo tokens from a prompt"
-    (agent/explicit-repos "fix yetibot/core and yetibot/yetibot please")
-    => ["yetibot/core" "yetibot/yetibot"])
-  (fact "dedupes"
-    (agent/explicit-repos "yetibot/core then yetibot/core") => ["yetibot/core"])
-  (fact "is empty for a plain English prompt"
-    (agent/explicit-repos "make the banana budget bigger") => []))
-
-(facts "about discover-repos"
-  (fact "prefers explicit repos and skips Gemini"
-    (agent/discover-repos "patch yetibot/core now") => ["yetibot/core"])
-  (fact "asks Gemini against the org list when none are explicit"
-    (agent/discover-repos "raise the image budget")
-    => ["yetibot/core"]
-    (provided (agent/list-org-repos "yetibot") => ["yetibot/core" "yetibot/yetibot"]
-              (agent/gemini-text anything) => "yetibot/core")))
-
-(facts "about authed-clone-url"
-  (fact "embeds the token for auth"
-    (agent/authed-clone-url "secret" "yetibot" "core")
-    => "https://x-access-token:secret@github.com/yetibot/core.git"))
-
-(facts "about branch-name"
-  (fact "is namespaced and unique-ish"
-    (agent/branch-name) => #(string/starts-with? % "yetibot/agent-")))
-
-(facts "about pr-title"
-  (fact "capitalizes and collapses whitespace"
-    (agent/pr-title "increase   banana budget") => "Increase banana budget")
-  (fact "truncates very long instructions"
-    (count (agent/pr-title (apply str (repeat 200 "x")))) => 72)
-  (fact "handles blank instruction"
-    (agent/pr-title "   ") => "Yetibot change"))
-
-(facts "about pr-body"
-  (fact "includes the instruction and embeds gemini output"
-    (agent/pr-body "do a thing" "some output")
-    => (contains "do a thing"))
-  (fact "embeds the gemini output"
-    (agent/pr-body "x" "some output") => (contains "some output")))
-
 (facts "about redact"
-  (fact "strips an embedded github token from a clone url"
-    (agent/redact "git clone https://x-access-token:supersecret@github.com/yetibot/core.git")
-    => "git clone https://x-access-token:***@github.com/yetibot/core.git")
+  (fact "strips an embedded token from a url"
+    (agent/redact "clone https://x-access-token:supersecret@github.com/yetibot/core.git")
+    => "clone https://x-access-token:***@github.com/yetibot/core.git")
+  (fact "strips a bare gh token"
+    (agent/redact "export GH_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+    => (contains "***"))
   (fact "tolerates nil"
     (agent/redact nil) => nil))
 
-(facts "about build-gemini-prompt"
-  (fact "tells the agent it can use the gh cli"
-    (agent/build-gemini-prompt "do x" nil) => (contains "gh"))
-  (fact "includes thread context when present"
-    (agent/build-gemini-prompt "do x" "alice: hi") => (contains "alice: hi"))
+(facts "about pr-urls"
+  (fact "extracts and dedupes pull request urls"
+    (agent/pr-urls "opened https://github.com/yetibot/core/pull/5 — see https://github.com/yetibot/core/pull/5")
+    => ["https://github.com/yetibot/core/pull/5"])
+  (fact "finds multiple"
+    (agent/pr-urls "https://github.com/a/b/pull/1 https://github.com/c/d/pull/2")
+    => ["https://github.com/a/b/pull/1" "https://github.com/c/d/pull/2"])
+  (fact "empty when none"
+    (agent/pr-urls "no prs here") => []))
+
+(facts "about build-agent-prompt"
+  (fact "tells gemini it can use the gh cli"
+    (agent/build-agent-prompt "do x" nil) => (contains "gh"))
+  (fact "instructs it to open a pull request"
+    (agent/build-agent-prompt "do x" nil) => (contains "pull request"))
+  (fact "includes conversation context when present"
+    (agent/build-agent-prompt "do x" "alice: hi") => (contains "alice: hi"))
   (fact "omits the context section when blank"
-    (agent/build-gemini-prompt "do x" "") => #(not (string/includes? % "context so far"))))
-
-(facts "about run-gemini"
-  (fact "invokes the cli with model/yolo/prompt and exports the keys + GH_TOKEN"
-    (agent/run-gemini "/tmp/repo" "increase banana budget" "" "ghs_tok")
-    => {:exit 0 :out "done" :err ""}
-    (provided
-     (agent/cli-bin) => "gemini"
-     (agent/gemini-key) => "test-key"
-     (agent/check-sh {:dir "/tmp/repo"
-                      :env {"GEMINI_API_KEY" "test-key"
-                            "GEMINI_CLI_TRUST_WORKSPACE" "true"
-                            "GH_TOKEN" "ghs_tok"}}
-                     "gemini" "--model" "gemini-2.5-pro" "--yolo"
-                     "--prompt" anything)
-     => {:exit 0 :out "done" :err ""})))
-
-(facts "about create-pull-request"
-  (fact "returns the PR body on success"
-    (agent/create-pull-request "tok" "yetibot" "core"
-                               {:title "T" :body "B" :head "h" :base "master"})
-    => {:html_url "https://github.com/yetibot/core/pull/1"}
-    (provided
-     (client/post "https://api.github.com/repos/yetibot/core/pulls" anything)
-     => {:status 201 :body {:html_url "https://github.com/yetibot/core/pull/1"}}))
-  (fact "throws on a non-2xx response"
-    (agent/create-pull-request "tok" "yetibot" "core"
-                               {:title "T" :body "B" :head "h" :base "master"})
-    => (throws clojure.lang.ExceptionInfo)
-    (provided
-     (client/post anything anything) => {:status 422 :body {:message "Validation Failed"}})))
-
-(facts "about run-repo"
-  (fact "returns the PR url on success"
-    (agent/run-repo "yetibot/core" "do x" "")
-    => {:repo "yetibot/core" :url "https://github.com/yetibot/core/pull/7"}
-    (provided (agent/github-token "yetibot" "core") => "tok"
-              (agent/file-pr anything)
-              => {:html_url "https://github.com/yetibot/core/pull/7"}))
-  (fact "flags no-changes"
-    (agent/run-repo "yetibot/core" "nothing" "")
-    => {:repo "yetibot/core" :no-changes true}
-    (provided (agent/github-token "yetibot" "core") => "tok"
-              (agent/file-pr anything)
-              =throws=> (ex-info "Gemini did not make any changes" {:type :no-changes})))
-  (fact "captures errors without throwing"
-    (agent/run-repo "yetibot/core" "boom" "")
-    => (contains {:repo "yetibot/core" :error anything})
-    (provided (agent/github-token "yetibot" "core") => "tok"
-              (agent/file-pr anything) =throws=> (ex-info "kaboom" {}))))
+    (agent/build-agent-prompt "do x" "") => #(not (string/includes? % "Conversation so far"))))
 
 (facts "about persona"
-  (fact "say-done lists PR urls for successes"
-    (agent/say-done [{:repo "yetibot/core" :url "https://x/pull/1"}])
-    => (contains "https://x/pull/1"))
-  (fact "say-done shows errors for failures"
-    (agent/say-done [{:repo "yetibot/core" :error "boom"}]) => (contains "boom")))
+  (fact "say-done lists PR urls on success"
+    (agent/say-done ["https://github.com/yetibot/core/pull/1"]) => (contains "pull/1"))
+  (fact "say-done copes with no PRs"
+    (agent/say-done []) => (contains "no PR"))
+  (fact "say-thinking echoes the request"
+    (agent/say-thinking "fix the thing") => (contains "fix the thing")))
 
 (facts "about agent-cmd guards"
   (fact "replies in persona when nothing is configured"
@@ -136,7 +54,33 @@
     => (contains "grug")
     (provided (agent/configured?) => false)))
 
-;; --- GitHub App auth (RS256 JWT, JDK crypto, PKCS#8 + PKCS#1) ---
+;; --- GitHub auth: enough to mint GH_TOKEN for Gemini ---
+
+(facts "about github auth config"
+  (fact "app-configured? requires both id and private key"
+    (agent/app-configured?) => true
+    (provided (agent/app-id) => "123" (agent/app-private-key) => "KEY"))
+  (fact "github-auth-configured? is satisfied by a PAT alone"
+    (agent/github-auth-configured?) => true
+    (provided (agent/app-configured?) => false (agent/github-pat) => "tok"))
+  (fact "configured? needs gemini and github auth"
+    (agent/configured?) => true
+    (provided (agent/gemini-key) => "k" (agent/github-auth-configured?) => true)))
+
+(facts "about github-token"
+  (fact "uses the static PAT when no App is configured"
+    (agent/github-token) => "pat"
+    (provided (agent/app-configured?) => false (agent/github-pat) => "pat"))
+  (fact "mints an App installation token, scoped to the whole installation"
+    (agent/github-token) => "ghs_org"
+    (provided
+     (agent/app-configured?) => true
+     (agent/app-jwt) => "jwt"
+     (agent/any-installation-id "jwt") => 99
+     (client/post "https://api.github.com/app/installations/99/access_tokens" anything)
+     => {:status 201 :body {:token "ghs_org"}})))
+
+;; --- RS256 JWT (JDK crypto, PKCS#8 + PKCS#1) ---
 
 (defn- rsa-keypair []
   (.generateKeyPair (doto (KeyPairGenerator/getInstance "RSA") (.initialize 2048))))
@@ -173,29 +117,3 @@
     (let [kp (rsa-keypair)]
       (:valid? (jwt-verifies? (agent/app-jwt) (.getPublic kp))) => true
       (provided (agent/app-id) => "123" (agent/app-private-key) => (pkcs1-pem kp)))))
-
-(facts "about github auth config"
-  (fact "app-configured? requires both id and private key"
-    (agent/app-configured?) => true
-    (provided (agent/app-id) => "123" (agent/app-private-key) => "KEY"))
-  (fact "github-auth-configured? is satisfied by a PAT alone"
-    (agent/github-auth-configured?) => true
-    (provided (agent/app-configured?) => false (agent/github-pat) => "tok")))
-
-(facts "about github-token resolution"
-  (fact "uses the static PAT when no App is configured"
-    (agent/github-token "yetibot" "core") => "pat"
-    (provided (agent/app-configured?) => false (agent/github-pat) => "pat"))
-  (fact "mints an installation token when an App is configured"
-    (agent/github-token "yetibot" "core") => "ghs_installation"
-    (provided (agent/app-configured?) => true
-              (agent/installation-token "yetibot" "core") => "ghs_installation")))
-
-(facts "about installation-token"
-  (fact "exchanges an app JWT for an installation access token"
-    (agent/installation-token "yetibot" "core") => "ghs_abc"
-    (provided
-     (agent/app-jwt) => "jwt"
-     (agent/installation-id "jwt" "yetibot" "core") => 42
-     (client/post "https://api.github.com/app/installations/42/access_tokens" anything)
-     => {:status 201 :body {:token "ghs_abc"}})))


### PR DESCRIPTION
Yetibot is just the middleman between Gemini and chat users.

- Hand the whole request to the Gemini CLI (headless, `--yolo`) running as an autonomous agent: it uses the authenticated `gh` CLI (`GH_TOKEN`) + git to find repos, make changes, and `gh pr create` itself.
- Stream Gemini's output live into the Discord thread (credential-redacted, capped) so users see progress; final grug summary scrapes PR URLs.
- Drops the in-Clojure discovery + clone/branch/PR machinery.
- Returns `(chat/suppress {})` so the framework stops posting "No results" into the parent channel.

21 midje checks; namespace compiles clean.