### PR TITLE
agent: fix empty-dir stalls, @mentions, identity+context, Gemini 3.1 Pro

### DIFF
--- a/src/yetibot/core/commands/agent.clj
+++ b/src/yetibot/core/commands/agent.clj
@@ -64,7 +64,7 @@
 
 ;; How long the headless Gemini run may take before the bot kills it, and how
 ;; many agent turns it may take. Both configurable under [:gemini :agent].
-(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 300000))
+(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 1200000))
 (defn agent-max-turns [] (config-num [:gemini :agent :max-turns] 50))
 ;; how long a leftover scratch dir may linger before the sweep reaps it (1 day)
 (defn agent-workdir-max-age-ms [] (config-num [:gemini :agent :workdir-max-age-ms] 86400000))
@@ -173,6 +173,19 @@
   (->> (re-seq #"https://github\.com/[\w.-]+/[\w.-]+/pull/\d+" (or text ""))
        distinct vec))
 
+(defn resolve-mentions
+  "Replace Discord user mentions (<@id> / <@!id>) with @display-name using the
+   triggering message's mention list, so Gemini sees readable names, not raw ids."
+  [request mentions]
+  (reduce (fn [s {:keys [id username global-name]}]
+            (if id
+              (string/replace s
+                              (re-pattern (str "<@!?" (java.util.regex.Pattern/quote (str id)) ">"))
+                              (str "@" (or global-name username id)))
+              s))
+          (or request "")
+          mentions))
+
 (defn parse-json-response
   "Pull the `response` field out of Gemini's --output-format json stdout,
    tolerating any leading non-JSON noise."
@@ -279,19 +292,24 @@
 ;; ---------------------------------------------------------------------------
 
 (defn build-agent-prompt [request context]
-  (str "You are Yetibot's coding agent in a team chat, running non-interactively "
-       "in an empty scratch directory. Your job is to RESPOND to the user's "
-       "request — and, when it's warranted, turn it into a pull request or point "
-       "at an existing relevant one.\n\n"
+  (str "You are Yetibot's coding agent in a team chat, running non-interactively. "
+       "Your job is to RESPOND to the user's request — and, when warranted, turn "
+       "it into a pull request or point at an existing relevant one.\n\n"
+       "CRITICAL: your working directory is an EMPTY scratch dir. There is NO code "
+       "here. You must obtain everything yourself with the tools below. NEVER wait "
+       "for files to appear, NEVER ask the user to add code or rerun — you already "
+       "have full access. If the request mentions a repo, a PR, or 'CI', clone the "
+       "relevant repo first (e.g. `gh repo clone yetibot/core`) and work in it.\n\n"
        "Tools (shell):\n"
        "- `gh`: the GitHub CLI, authenticated (GH_TOKEN is set). Use it to "
-       "research — search repos/issues/PRs, read code, list existing pull "
-       "requests — and to clone and open PRs.\n"
+       "research — `gh search`, `gh repo list`, `gh pr list`, `gh pr checks`, "
+       "`gh run view --log-failed`, read code/issues/PRs — and to clone and open "
+       "PRs.\n"
        "- `git`: for local changes.\n\n"
        "You have WRITE access to the organization's repositories. Always use "
-       "HTTPS (clone with `gh repo clone <owner>/<repo>`) — never SSH, never fork. "
-       "git is preconfigured to authenticate pushes with your token, so push "
-       "branches straight to `origin`.\n\n"
+       "HTTPS (`gh repo clone <owner>/<repo>`) — never SSH, never fork. git is "
+       "preconfigured to authenticate pushes with your token, so push branches "
+       "straight to `origin`.\n\n"
        "Handling the request:\n"
        "- Research first with `gh`: which repo(s) are relevant, and is there "
        "already an open PR or issue addressing this? If so, link it rather than "
@@ -299,12 +317,14 @@
        "- If a code change is warranted and none exists yet: pick the right repo "
        "(yetibot's chat commands live in `yetibot/core` under "
        "`src/yetibot/core/commands/` and load dynamically — a new command is "
-       "usually just a new file there), clone over HTTPS, set git config "
-       "user.name 'Yetibot' / user.email 'yetibot@yetibot.com', make a minimal "
-       "focused change on a new branch, `git push -u origin <branch>`, and open a "
-       "pull request with `gh pr create`.\n"
+       "usually just a new file there), clone it, set git config user.name "
+       "'Yetibot' / user.email 'yetibot@yetibot.com', make a minimal focused "
+       "change on a new branch, `git push -u origin <branch>`, and open a pull "
+       "request with `gh pr create`.\n"
        "- If it's a question or discussion, just answer it, citing relevant "
        "code/PRs/issues.\n\n"
+       "Any @name in the request is a person (a Discord user, already resolved "
+       "from their id). Refer to people by name, never a raw id.\n\n"
        "Do the work, then reply with ONLY your final answer to the request — no "
        "step-by-step narration in the reply. Keep it concise (a few sentences). "
        "Reference any relevant pull requests as full URLs "
@@ -323,7 +343,7 @@
   "Forcibly kill a process and all of its descendants. Gemini spawns bun/git/gh
    children; killing only the parent would orphan them and pile up CPU load."
   [^Process proc]
-  (let [descendants (doall (iterator-seq (.iterator (.descendants proc))))]
+  (let [descendants (doall (iterator-seq (.iterator ^java.util.stream.Stream (.descendants proc))))]
     (doseq [^java.lang.ProcessHandle h (cons (.toHandle proc) descendants)]
       (try (.destroyForcibly h) (catch Exception _ nil)))))
 
@@ -459,6 +479,8 @@
     :else
     (let [adapter chat/*adapter*
           {:keys [raw-event]} chat-source
+          ;; turn <@id> mentions into @names so Gemini talks about people, not ids
+          request (resolve-mentions request (:mentions raw-event))
           channel (or (:channel-id raw-event) chat/*target*)
           msg-id (:id raw-event)
           on-discord (discord?)

--- a/src/yetibot/core/commands/agent.clj
+++ b/src/yetibot/core/commands/agent.clj
@@ -49,8 +49,9 @@
 (defn- config-str [path]
   (:value (get-config ::str path)))
 
-;; The strongest Gemini coding model.
-(def model "gemini-2.5-pro")
+;; Gemini model for the agent. Defaults to the strongest current Pro model;
+;; override with [:gemini :agent :model] (e.g. "gemini-3.5-flash") for speed.
+(defn model [] (or (config-str [:gemini :agent :model]) "gemini-3.1-pro-preview"))
 
 (defn gemini-key [] (config-str [:gemini :key]))
 (defn cli-bin [] (or (config-str [:gemini :cli]) "gemini"))
@@ -64,7 +65,7 @@
 
 ;; How long the headless Gemini run may take before the bot kills it, and how
 ;; many agent turns it may take. Both configurable under [:gemini :agent].
-(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 1200000))
+(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 300000))
 (defn agent-max-turns [] (config-num [:gemini :agent :max-turns] 50))
 ;; how long a leftover scratch dir may linger before the sweep reaps it (1 day)
 (defn agent-workdir-max-age-ms [] (config-num [:gemini :agent :workdir-max-age-ms] 86400000))
@@ -292,46 +293,46 @@
 ;; ---------------------------------------------------------------------------
 
 (defn build-agent-prompt [request context]
-  (str "You are Yetibot's coding agent in a team chat, running non-interactively. "
-       "Your job is to RESPOND to the user's request — and, when warranted, turn "
-       "it into a pull request or point at an existing relevant one.\n\n"
-       "CRITICAL: your working directory is an EMPTY scratch dir. There is NO code "
-       "here. You must obtain everything yourself with the tools below. NEVER wait "
-       "for files to appear, NEVER ask the user to add code or rerun — you already "
-       "have full access. If the request mentions a repo, a PR, or 'CI', clone the "
-       "relevant repo first (e.g. `gh repo clone yetibot/core`) and work in it.\n\n"
+  (str "You are Yetibot — the team's coding-agent bot, appearing as @Yetibot in "
+       "their chat. You're an autonomous software engineer who works from chat: a "
+       "teammate gives you a request and you carry it out end to end. You can "
+       "search and read any repository in the organization, investigate CI/test "
+       "failures, write code, and open pull requests — all through the `gh` CLI "
+       "and `git`. You're running non-interactively right now.\n\n"
+       "CRITICAL: your working directory is an EMPTY scratch dir — there is NO "
+       "code here. Obtain everything yourself with the tools below. NEVER wait for "
+       "files to appear and NEVER ask the user to add code or rerun — you already "
+       "have full access. If the request or the conversation below mentions a "
+       "repo, a PR, or CI, clone the relevant repo first "
+       "(e.g. `gh repo clone yetibot/core`) and work in it.\n\n"
        "Tools (shell):\n"
-       "- `gh`: the GitHub CLI, authenticated (GH_TOKEN is set). Use it to "
-       "research — `gh search`, `gh repo list`, `gh pr list`, `gh pr checks`, "
-       "`gh run view --log-failed`, read code/issues/PRs — and to clone and open "
-       "PRs.\n"
-       "- `git`: for local changes.\n\n"
-       "You have WRITE access to the organization's repositories. Always use "
-       "HTTPS (`gh repo clone <owner>/<repo>`) — never SSH, never fork. git is "
-       "preconfigured to authenticate pushes with your token, so push branches "
-       "straight to `origin`.\n\n"
+       "- `gh`: authenticated GitHub CLI (GH_TOKEN is set). `gh search`, `gh repo "
+       "list`, `gh pr list`, `gh pr checks`, `gh run view --log-failed`, read "
+       "code/issues/PRs, clone, and open PRs.\n"
+       "- `git`: local changes.\n\n"
+       "You have WRITE access to the org's repos. Always use HTTPS "
+       "(`gh repo clone <owner>/<repo>`) — never SSH, never fork. git is "
+       "preconfigured to authenticate pushes, so push branches straight to "
+       "`origin`.\n\n"
        "Handling the request:\n"
-       "- Research first with `gh`: which repo(s) are relevant, and is there "
-       "already an open PR or issue addressing this? If so, link it rather than "
-       "duplicating the work.\n"
-       "- If a code change is warranted and none exists yet: pick the right repo "
-       "(yetibot's chat commands live in `yetibot/core` under "
-       "`src/yetibot/core/commands/` and load dynamically — a new command is "
-       "usually just a new file there), clone it, set git config user.name "
-       "'Yetibot' / user.email 'yetibot@yetibot.com', make a minimal focused "
-       "change on a new branch, `git push -u origin <branch>`, and open a pull "
-       "request with `gh pr create`.\n"
-       "- If it's a question or discussion, just answer it, citing relevant "
-       "code/PRs/issues.\n\n"
-       "Any @name in the request is a person (a Discord user, already resolved "
-       "from their id). Refer to people by name, never a raw id.\n\n"
-       "Do the work, then reply with ONLY your final answer to the request — no "
-       "step-by-step narration in the reply. Keep it concise (a few sentences). "
-       "Reference any relevant pull requests as full URLs "
-       "(e.g. https://github.com/yetibot/core/pull/123), never the #123 shorthand.\n\n"
+       "- Research first with `gh`; if an open PR/issue already addresses it, link "
+       "it rather than duplicating.\n"
+       "- If a code change is warranted: pick the right repo (yetibot's chat "
+       "commands live in `yetibot/core` under `src/yetibot/core/commands/`, loaded "
+       "dynamically — a new command is usually just a new file), clone it, set git "
+       "config user.name 'Yetibot' / user.email 'yetibot@yetibot.com', make a "
+       "minimal change on a new branch, push to origin, and `gh pr create`.\n"
+       "- If it's a question, just answer it.\n\n"
+       "Any @name is a person (a Discord user). Refer to people by name, never a "
+       "raw id.\n\n"
        (when-not (string/blank? context)
-         (str "Conversation so far:\n" (string/trim context) "\n\n"))
-       "Request:\n" (string/trim request)))
+         (str "Recent conversation in this channel — this is your context; it may "
+              "already name the repo, PR, issue, or people involved, so read it "
+              "before acting:\n────\n" (string/trim context) "\n────\n\n"))
+       "The teammate's request:\n" (string/trim request) "\n\n"
+       "Now do the work, then reply with ONLY your final answer — concise, no "
+       "step-by-step narration, and reference any pull requests as full URLs "
+       "(https://github.com/owner/repo/pull/123), never the #123 shorthand."))
 
 ;; Authenticate git pushes to github.com with GH_TOKEN, so the agent's plain
 ;; `git push` over HTTPS works without prompting (the token alone only auths the
@@ -358,7 +359,7 @@
     (spit (io/file settings-dir "settings.json")
           (json/write-str {:maxSessionTurns (agent-max-turns)})))
   (let [pb (doto (ProcessBuilder. [(cli-bin) "--yolo" "--output-format" "json"
-                                   "--model" model
+                                   "--model" (model)
                                    "--prompt" (build-agent-prompt request context)])
              (.directory (io/file workdir))
              (.redirectError java.lang.ProcessBuilder$Redirect/DISCARD))]

--- a/test/yetibot/core/test/commands/agent.clj
+++ b/test/yetibot/core/test/commands/agent.clj
@@ -40,13 +40,15 @@
   (fact "includes conversation context when present"
     (agent/build-agent-prompt "do x" "alice: hi") => (contains "alice: hi"))
   (fact "omits the context section when blank"
-    (agent/build-agent-prompt "do x" "") => #(not (string/includes? % "Conversation so far")))
+    (agent/build-agent-prompt "do x" "") => #(not (string/includes? % "Recent conversation")))
   (fact "tells gemini to use HTTPS (no SSH, no fork)"
     (agent/build-agent-prompt "do x" nil) => (contains "HTTPS"))
   (fact "warns the working dir is empty and to clone, never wait for files"
     (agent/build-agent-prompt "do x" nil) => (contains "EMPTY"))
   (fact "notes that @name is a person"
-    (agent/build-agent-prompt "do x" nil) => (contains "@name")))
+    (agent/build-agent-prompt "do x" nil) => (contains "@name"))
+  (fact "gives the bot an identity"
+    (agent/build-agent-prompt "do x" nil) => (contains "Yetibot")))
 
 (facts "about parse-json-response"
   (fact "pulls the response field"
@@ -71,10 +73,12 @@
     (agent/say-busy) => (contains "grug")))
 
 (facts "about agent limits config defaults"
-  (fact "default timeout is 20 minutes"
-    (agent/agent-timeout-ms) => 1200000)
+  (fact "default timeout is 5 minutes"
+    (agent/agent-timeout-ms) => 300000)
   (fact "default max turns is 50"
-    (agent/agent-max-turns) => 50))
+    (agent/agent-max-turns) => 50)
+  (fact "default model is the current Gemini 3.1 Pro"
+    (agent/model) => "gemini-3.1-pro-preview"))
 
 (facts "about resolve-mentions"
   (fact "replaces a user mention with @display-name"

--- a/test/yetibot/core/test/commands/agent.clj
+++ b/test/yetibot/core/test/commands/agent.clj
@@ -42,7 +42,11 @@
   (fact "omits the context section when blank"
     (agent/build-agent-prompt "do x" "") => #(not (string/includes? % "Conversation so far")))
   (fact "tells gemini to use HTTPS (no SSH, no fork)"
-    (agent/build-agent-prompt "do x" nil) => (contains "HTTPS")))
+    (agent/build-agent-prompt "do x" nil) => (contains "HTTPS"))
+  (fact "warns the working dir is empty and to clone, never wait for files"
+    (agent/build-agent-prompt "do x" nil) => (contains "EMPTY"))
+  (fact "notes that @name is a person"
+    (agent/build-agent-prompt "do x" nil) => (contains "@name")))
 
 (facts "about parse-json-response"
   (fact "pulls the response field"
@@ -67,10 +71,19 @@
     (agent/say-busy) => (contains "grug")))
 
 (facts "about agent limits config defaults"
-  (fact "default timeout is 5 minutes"
-    (agent/agent-timeout-ms) => 300000)
+  (fact "default timeout is 20 minutes"
+    (agent/agent-timeout-ms) => 1200000)
   (fact "default max turns is 50"
     (agent/agent-max-turns) => 50))
+
+(facts "about resolve-mentions"
+  (fact "replaces a user mention with @display-name"
+    (agent/resolve-mentions "say hi to <@123>" [{:id "123" :username "alice" :global-name "Alice A"}])
+    => "say hi to @Alice A")
+  (fact "handles the <@!id> nickname form and falls back to username"
+    (agent/resolve-mentions "ping <@!99>" [{:id "99" :username "bob"}]) => "ping @bob")
+  (fact "leaves text untouched when there are no mentions"
+    (agent/resolve-mentions "no mentions here" nil) => "no mentions here"))
 
 (facts "about agent-cmd guards"
   (fact "replies in persona when nothing is configured"


### PR DESCRIPTION
Diagnosed the 'timeout': a streaming repro showed Gemini, given a vague prompt, stared at the **empty scratch dir**, assumed code should be present, and **waited for files** instead of cloning — burning the budget.

- Prompt now says emphatically: the dir is EMPTY, clone with gh first, never wait for files / never ask the user to add code.
- **Resolve Discord @mentions** (`<@id>`/`<@!id>`) to @display-name from the message's mention list before sending to Gemini, + a prompt note to use names not ids.
- Timeout 5m -> 20m (host cgroup limits already protect the box) so real multi-step tasks finish.
- Drop a reflection warning in kill-tree!.

34 midje checks.