### PR TITLE
feat(veo): use @mentioned avatars as image-to-video input

### DIFF
--- a/src/yetibot/core/commands/veo.clj
+++ b/src/yetibot/core/commands/veo.clj
@@ -1,6 +1,7 @@
 (ns yetibot.core.commands.veo
   (:require [taoensso.timbre :refer [info error]]
             [yetibot.core.hooks :refer [cmd-hook]]
+            [yetibot.core.util.image-input :as image-input]
             [yetibot.core.util.gemini :as gemini]
             [yetibot.core.webapp.routes.images :refer [store-image!]]))
 
@@ -10,18 +11,19 @@
    Examples:
    veo a cat jumping
    veo a robot dancing in times square
-   veo mind blown explosion"
+   veo make @someone breakdance"
   {:yb/cat #{:img :gif}}
-  [{:keys [match]}]
+  [{:keys [match chat-source]}]
   (if (gemini/configured?)
     (try
-      (info "veo: generating video for:" match)
-      (let [video (gemini/generate-video match)
-            id (store-image! video)
-            url (format "%s/generated-images/%s.mp4" (gemini/yetibot-base-url) id)]
-        (info "veo: video generated, serving at" url)
-        {:result/value url
-         :result/data {:id id :prompt match :url url}})
+      (let [{:keys [prompt image-urls]} (image-input/extract-images match chat-source)]
+        (info "veo: generating video for:" prompt "with" (count image-urls) "input image(s)")
+        (let [video (gemini/generate-video prompt image-urls)
+              id (store-image! video)
+              url (format "%s/generated-images/%s.mp4" (gemini/yetibot-base-url) id)]
+          (info "veo: video generated, serving at" url)
+          {:result/value url
+           :result/data {:id id :prompt match :url url}}))
       (catch Exception e
         (error "veo: generation error:" (.getMessage e))
         {:result/error (str "Video generation failed: " (.getMessage e))}))

--- a/src/yetibot/core/util/gemini.clj
+++ b/src/yetibot/core/util/gemini.clj
@@ -298,11 +298,22 @@
 (def ^:private veo-poll-interval-ms 6000)
 (def ^:private veo-max-polls 50) ; ~5 min ceiling
 
+(defn- veo-image-part
+  "Fetch an image URL and return a Veo instance image (base64), or nil. Used for
+   image-to-video — e.g. a mentioned Discord user's avatar becomes the opening frame."
+  [image-url]
+  (let [resp (client/get image-url {:as :byte-array :throw-exceptions false})
+        mime (first (string/split (get-in resp [:headers "Content-Type"] "image/png") #";"))]
+    (when (<= 200 (:status resp) 299)
+      {:mimeType mime
+       :bytesBase64Encoded (.encodeToString (Base64/getEncoder) ^bytes (:body resp))})))
+
 (defn- veo-start
-  "Kick off a Veo generation; returns the long-running operation name."
-  [prompt]
+  "Kick off a Veo generation; returns the long-running operation name.
+   When `image` is provided, Veo conditions the video on it (image-to-video)."
+  [prompt image]
   (let [url (format "%s/models/%s:predictLongRunning?key=%s" api-base (veo-model) (:key config))
-        body {:instances [{:prompt prompt}]
+        body {:instances [(cond-> {:prompt prompt} image (assoc :image image))]
               :parameters {:aspectRatio "16:9" :durationSeconds (veo-duration)}}
         resp (client/post url {:content-type :json
                                :body (json/write-str body)
@@ -344,16 +355,18 @@
 (defn generate-video
   "Generate a short video with Veo from a text prompt. Checks the monthly budget,
    polls the long-running operation, downloads the result, and records usage.
+   Optional image-urls condition the video (image-to-video); the first is used.
    Returns {:data <base64 mp4> :mime-type \"video/mp4\"}."
-  [prompt]
-  (check-budget!)
-  (let [op (veo-start prompt)
-        _ (info "veo: generation started" op)
-        done (veo-poll op)
-        uri (get-in done [:response :generateVideoResponse :generatedSamples 0 :video :uri])]
-    (when (string/blank? uri)
-      (throw (ex-info "No video was generated. Try a different prompt."
-                      {:type :no-video-generated :response (:response done)})))
-    (let [data (veo-download uri)]
-      (record-image-generated! (veo-cost-units))
-      {:data data :mime-type "video/mp4"})))
+  ([prompt] (generate-video prompt nil))
+  ([prompt image-urls]
+   (check-budget!)
+   (let [op (veo-start prompt (some-> (first image-urls) veo-image-part))
+         _ (info "veo: generation started" op)
+         done (veo-poll op)
+         uri (get-in done [:response :generateVideoResponse :generatedSamples 0 :video :uri])]
+     (when (string/blank? uri)
+       (throw (ex-info "No video was generated. Try a different prompt."
+                       {:type :no-video-generated :response (:response done)})))
+     (let [data (veo-download uri)]
+       (record-image-generated! (veo-cost-units))
+       {:data data :mime-type "video/mp4"}))))


### PR DESCRIPTION
Follow-up to #249.

## Why
`!veo make @someone dance` ignored the mention. `banana`/`bagif` resolve @-mentions to the user's avatar (via `image-input/extract-images`) and feed it as an image input; `veo` was text-only.

## What
- `veo-cmd` now runs `image-input/extract-images` (same as banana) to pull the cleaned prompt + image URLs (Discord @mention avatars, message attachments, inline image URLs).
- `gemini/generate-video` gains an optional `image-urls` arg; the first image is fetched and passed as Veo's **image-to-video** conditioning frame (`instances[0].image = {bytesBase64Encoded, mimeType}`).

So mentioning a user opens the clip on their profile picture, matching banana's behavior.

## Note
The image-to-video request shape follows the documented Veo REST format; the live i2v path is **not yet verified** end-to-end (a real Veo i2v call bills). Text-to-video is already confirmed working in prod.