### PR TITLE
feat(agent): 15-min timeout, remove single-run concurrency cap

### DIFF
--- a/src/yetibot/core/commands/agent.clj
+++ b/src/yetibot/core/commands/agent.clj
@@ -65,7 +65,7 @@
 
 ;; How long the headless Gemini run may take before the bot kills it, and how
 ;; many agent turns it may take. Both configurable under [:gemini :agent].
-(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 300000))
+(defn agent-timeout-ms [] (config-num [:gemini :agent :timeout-ms] 900000))
 (defn agent-max-turns [] (config-num [:gemini :agent :max-turns] 50))
 ;; how long a leftover scratch dir may linger before the sweep reaps it (1 day)
 (defn agent-workdir-max-age-ms [] (config-num [:gemini :agent :workdir-max-age-ms] 86400000))
@@ -439,14 +439,6 @@
 ;; Command
 ;; ---------------------------------------------------------------------------
 
-;; One agent run at a time: each spawns Gemini (bun/node) + git clones, which on
-;; a small host easily over-subscribes the CPU. Excess invocations are turned
-;; away rather than queued.
-(defonce ^:private run-permit (java.util.concurrent.Semaphore. 1))
-
-(defn say-busy []
-  "🦴 grug already smashing one rock — wait til grug finish, then ask again 🪨")
-
 (defn run-agent
   "Async body: mint a token, run Gemini headlessly, then delete the transient
    status message and post one clean final reply — Gemini's answer plus links to
@@ -481,7 +473,6 @@
   [{[_ request] :match chat-source :chat-source}]
   (cond
     (not (configured?)) (say-unconfigured)
-    (not (.tryAcquire run-permit)) (say-busy)
     :else
     (let [adapter chat/*adapter*
           {:keys [raw-event]} chat-source
@@ -498,11 +489,9 @@
           ;; transient status; deleted when the final answer is posted
           status-id (:id (binding [chat/*target* target] (chat/send-msg (say-working))))]
       (future
-        (try
-          (binding [chat/*adapter* adapter]
-            (run-agent {:request request :target target :context-channel channel
-                        :on-discord on-discord :status-id status-id :mentions mentions}))
-          (finally (.release run-permit))))
+        (binding [chat/*adapter* adapter]
+          (run-agent {:request request :target target :context-channel channel
+                      :on-discord on-discord :status-id status-id :mentions mentions})))
       ;; the answer is posted out of band; suppress the framework's reply
       (chat/suppress {}))))
 

--- a/test/yetibot/core/test/commands/agent.clj
+++ b/test/yetibot/core/test/commands/agent.clj
@@ -70,13 +70,11 @@
   (fact "say-final copes with a blank answer"
     (agent/say-final "" nil) => (contains "done"))
   (fact "say-timeout names the limit"
-    (agent/say-timeout 5) => (contains "5 min"))
-  (fact "say-busy explains the agent is occupied"
-    (agent/say-busy) => (contains "grug")))
+    (agent/say-timeout 5) => (contains "5 min")))
 
 (facts "about agent limits config defaults"
-  (fact "default timeout is 5 minutes"
-    (agent/agent-timeout-ms) => 300000)
+  (fact "default timeout is 15 minutes"
+    (agent/agent-timeout-ms) => 900000)
   (fact "default max turns is 50"
     (agent/agent-max-turns) => 50)
   (fact "default model is the current Gemini 3.1 Pro"


### PR DESCRIPTION
## What
- **Timeout**: `agent-timeout-ms` default 300000 → **900000ms (15 min)** (still overridable via `[:gemini :agent :timeout-ms]`).
- **Concurrency**: removed the one-run-at-a-time `Semaphore` (`run-permit`) and the "🦴 grug already smashing one rock" busy reply. `!agent` requests now run **concurrently with no cap**.

Each run is still bounded by the `kill-tree!` wall-clock watchdog and isolated per-run `/tmp` scratch dirs, so a hung run self-terminates and runs don't share state.

## Note
No concurrency limit means N simultaneous `!agent` calls spawn N Gemini (bun/node) + git-clone trees. On a small host that can over-subscribe CPU; the box was resized to 16GB so OOM is unlikely, but heavy parallelism on 2 cores will be slow.