### PR TITLE
fix(agent): render hmmm custom emoji in pending status

### DIFF
--- a/src/yetibot/core/commands/agent.clj
+++ b/src/yetibot/core/commands/agent.clj
@@ -104,7 +104,7 @@
 (defn say-working
   "Transient status message, deleted once Gemini returns its final answer."
   []
-  ":hmmm: grug on it…")
+  "<:hmmm:1494137019805466734> grug on it…")
 
 (defn say-final
   "The clean final reply: Gemini's summary plus links to any relevant PRs."


### PR DESCRIPTION
The pending status used the literal `:hmmm:` shortcode, which Discord does NOT convert to a custom emoji in bot message content — it showed as plain text. Use the full custom-emoji token `<:hmmm:1494137019805466734>` (static; the `.gif` CDN variant 415s) so it renders.